### PR TITLE
Add link to MDN’s HTML Basics

### DIFF
--- a/year1/units/unit1/README.md
+++ b/year1/units/unit1/README.md
@@ -28,3 +28,5 @@ In this unit students will be introduced to HTML. They will learn tag structure 
 
 [Common Core & Computer Science Standards Alignment](csStandards.md)
 
+[HTML basics (MDN)](https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/HTML_basics)
+


### PR DESCRIPTION
MDN’s [HTML Basics](https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/HTML_basics) page is good “further reading” for students who want to explore the lesson topics more deeply.

(Side note: is this the right place for this link?)
