### PR TITLE
Add space after header hash marks for Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 |[Advanced Course](year2)| The focus of this course is **Experience**. In this course the students further develop their web development technical skills through lessons and projects that interact with JSON and popular APIs. Students will also be challenged to improve their professional skills in this course.|
 |ScriptEd Studio| The focus of this course is **Agency**. The ScriptEd Studio provides ScriptEd's most experienced students with the opportunity to complete passion projects with help from ScriptEd mentors.|
 
-####For more information about ScriptEd go to [scripted.org](https://www.scripted.org)
+#### For more information about ScriptEd go to [scripted.org](https://www.scripted.org)
 
   <br>
 

--- a/miscLessons/commandLine/README.md
+++ b/miscLessons/commandLine/README.md
@@ -1,4 +1,4 @@
-#Lesson 1 - Command Line Basics
+# Lesson 1 - Command Line Basics
 
 ![image](http://i.imgur.com/FJ5Hsq0.jpg)
 
@@ -131,7 +131,7 @@ Give [exit ticket](assessments/exit_ticket.md).
 Today, you learned about the **command line**. This is important because the **command line** lets us talk to the computer in a defined and quick way. Also, the **command line** has not changed in decades and shows no signs of changing in the future.
 
 
-###How to Submit
+### How to Submit
 This project is not required to be submitted as projects in the past have been. Students may save this workspace in their Cloud9 account.
 
 ### Homework

--- a/miscLessons/googling101/README.md
+++ b/miscLessons/googling101/README.md
@@ -1,11 +1,11 @@
-#Misc Lesson: Googling 101 
+# Misc Lesson: Googling 101 
 
 ![Imgur](http://i.imgur.com/LBhbHpD.jpg)
 
-##Summary (45 minutes)
+## Summary (45 minutes)
 In this lesson, the students will learn how to get the most out of their Google searches. Students will be taught how to make their searches brief yet powerful. Teachers will share best practices through mini-activities.
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * Less is more!
 * Encourage students to start every search with the language they are working in.
 * Please leave personal opinions to a minimum! Stick to facts about websearches.

--- a/miscLessons/scratchUnit/README.md
+++ b/miscLessons/scratchUnit/README.md
@@ -1,18 +1,18 @@
-#Programming with Scratch
+# Programming with Scratch
 
-##Synopsis
+## Synopsis
 In this unit, students will begin work on Scratch 2.0. Scratch is a block-based programming language that allows for visual representation of a computer program without using any syntax. Through three quick activities in Scratch, students will obtain a basice knowledge of creating Algorithms, Variables, and Boolean Logic. 
 
-##Lessons
+## Lessons
 
 1. [Algorithms](lessons/1-algorithms)
 2. [Variables](lessons/2-variables)
 3. [Boolean Logic](lessons/3-ifElse)
 4. [Project: Ol' McDonald MadLibs](lessons/4-project)
 
-##Standards
+## Standards
 
-####English Standards
+#### English Standards
 
 [CCSS.ELA-LITERACY.L9-10.1](http://www.corestandards.org/ELA-Literacy/L/9-10/1/)
 
@@ -26,13 +26,13 @@ Use parallel structure.
 
 Use various types of phrases (noun, verb, adjectival, adverbial, participial, prepositional, absolute) and clauses (independent, dependent; noun, relative, adverbial) to convey specific meanings and add variety and interest to writing or presentations.
 
-####CSTA Standards
+#### CSTA Standards
 
 **CT.L2-03** Define an algorithm as a sequence of instructions that can be processed by a computer. 
 
 **CT.L2-04** Evaluate ways that different algorithms may be used to solve the same problem. 
 
-####ScriptEd Standards
+#### ScriptEd Standards
 
 **CPP.L2-03: Variables**  
 * Student can create, name, and assign values to variables. 

--- a/miscLessons/scratchUnit/lessons/1-algorithms/README.md
+++ b/miscLessons/scratchUnit/lessons/1-algorithms/README.md
@@ -1,10 +1,10 @@
-#Lesson 1 - Algorithms
+# Lesson 1 - Algorithms
 
 ![image](http://i.imgur.com/tM1CA61.png)
 
 ## Before Class
 ---
-###Teacher Preparation
+### Teacher Preparation
 * A basic understanding of Scratch. Teacher should be familiar with motion, looks, control and event blocks. 
 
 

--- a/miscLessons/scratchUnit/lessons/2-variables/README.md
+++ b/miscLessons/scratchUnit/lessons/2-variables/README.md
@@ -4,7 +4,7 @@
 
 ## Before Class
 ---
-###Teacher Preparation
+### Teacher Preparation
 * A further understanding of Scratch. Teacher should be familiar with sensing, control, operator and data blocks.
 
 ### Daily Objective

--- a/miscLessons/scratchUnit/lessons/3-ifElse/README.md
+++ b/miscLessons/scratchUnit/lessons/3-ifElse/README.md
@@ -4,7 +4,7 @@
 
 ## Before Class
 
-###Teacher Preparation
+### Teacher Preparation
 * A further understanding of Scratch. Teacher should be familiar with control, sensing and data blocks.
 * The teacher should create a two variable MadLibs program with a logic condition before entering the classroom.  **This will be the final project that students do in the next lesson.**
 

--- a/miscLessons/scratchUnit/lessons/4-project/README.md
+++ b/miscLessons/scratchUnit/lessons/4-project/README.md
@@ -2,11 +2,11 @@
 
 ![image](http://i.imgur.com/OLUMwTX.jpg)
 
-##Overview
+## Overview
 
 This project involves creating a Madlibs program in Scratch that also includes an If/Else statement.
 
-##Before Class
+## Before Class
 
 ### Prerequisites
 
@@ -15,7 +15,7 @@ Students should only start this project after they have completed the other less
 ### Starter Code
 Students can begin with a blank canvas on scratch.mit.edu
 
-###References
+### References
 
 * <http://scratch.mit.edu>, use the "Create" tab
 * <http://www.madglibs.com/showglib.php?glibid=185>
@@ -26,19 +26,19 @@ Students can begin with a blank canvas on scratch.mit.edu
 
 This project will be graded as a summative assessment.
 
-##During Class
+## During Class
 
-###Do Now
+### Do Now
 
 1. Volunteer takes attendance. [Procedure found here](https://docs.google.com/document/d/19IIhqykr70vj7wnqyJYuQNTkd9GX56Xgl3omD42IcMk/edit).
 2. Hand students a printed copy of the [MadLibs activity](http://www.madglibs.com/printglib.php?glibid=185) OR students may complete [online version](http://www.madglibs.com/showglib.php?glibid=185) (links provided in reference section.)
 
-###Opening
+### Opening
 
 “Please complete the MadLibs activity as a refresher to the parts of speech.” Allow 3-4 minutes to complete. Once complete, have some students share their MadLibs game. Then have a class conversation revolving around variables in a game of MadLibs." 
 
 
-###Introduction to New Material ("I Do")
+### Introduction to New Material ("I Do")
 You are going to build a MadLibs game using Scratch. This madlibs game will combine the skills we have learned in previous lessons. It must begin with boolean logic before beginning the game. 
 
 You are to create a program that includes the following:
@@ -56,18 +56,18 @@ Additional Guidelines:
 * Note that the "log" button is not natural log (base e) but log base 10.
 * The random number button should generate a number between 1 and 1000.
 
-###Independent Practice ("You Do")
+### Independent Practice ("You Do")
 It's build time! Students will work alone on this project. The teacher's role will be to walk around the room helping students with any questions they have. Students are encouraged to look at previous lessons for reference.
 
-###Extension Activities
+### Extension Activities
 Students who complete the project early may attempt to improve their project by changing the costume of Scratchy the Cat based on the animal selected in the MadLibs game.
 
-###Closing
+### Closing
 Reflect on this project with a discussion. What was challenging, what was easy, etc.. The teacher should explain some of the benefits and downfalls of Scratch and explain that you will be moving onto JavaScript next class.
 
-###Check for Understanding
+### Check for Understanding
 Teachers will grade this project for completion and correctness.
 
-###How to Submit Project
+### How to Submit Project
 * The students must export this project as a Gist: File > Export as Gist
 * The teacher must ask students to share the link to their project at [bit.ly/ScriptEdProjects](https://bit.ly/ScriptEdProjects).

--- a/miscLessons/this/README.md
+++ b/miscLessons/this/README.md
@@ -1,10 +1,10 @@
-#Misc Lesson: this 
+# Misc Lesson: this 
 
 ![Imgur](http://i.imgur.com/rFf5gqUm.jpg)
 
-##Summary (45 minutes)
+## Summary (45 minutes)
 In this lesson, the students will be introduced to this in terms of jQuery events. This lesson does not touch on `this` in terms of its use in objects. It is intended to be taught to students of varying abilities.
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * `this` is similar to the use of pronouns
 
 

--- a/year1/README.md
+++ b/year1/README.md
@@ -1,4 +1,4 @@
-###ScriptEd Curriculum 2016-2017
+### ScriptEd Curriculum 2016-2017
 
 Year 1
 ===================
@@ -22,7 +22,7 @@ Year 1
 | 360 minutes | [**14**](units/unit14) | Capstone Project |Students will be compiling all their knowledge from the year in a final project which resembles a "space invaders" style game. |
 
 
-####Misc Lessons, Games and Projects
+#### Misc Lessons, Games and Projects
 
 | Lesson | Description |
 |-------|:-------:|
@@ -39,7 +39,7 @@ Year 1
 ![Imgur](http://i.imgur.com/P6Mdcqe.png)
 This calendar is a recommended schedule to be followed in ScriptEd courses.
 
-##School Teacher Resources
+## School Teacher Resources
 
 * [Pacing Guide for in-class teachers](https://docs.google.com/document/d/1OMvWCohkD68hIjBKMevw99etwpVFE32XCBaGakV6eB8/edit?usp=sharing): To be used in ScriptEd course that are co-taught with a teacher from the school.
 * [CodeCademy Class Creator Guidelines](https://docs.google.com/document/d/1-6vh1QM2h0tZzTIl_183C_lt7ezv_pQ-QXsHQKkDAgQ/edit)  

--- a/year1/units/unit0/README.md
+++ b/year1/units/unit0/README.md
@@ -1,4 +1,4 @@
-#Unit 0: Routines & Introductions
+# Unit 0: Routines & Introductions
 
 This unit consists of icebreaker activities for students and teachers. This unit will also be most students' first interaction with HTML.
 
@@ -7,10 +7,10 @@ This unit consists of icebreaker activities for students and teachers. This unit
 | [1 Elements & Icebreakers](topics/topic1)| After completing some icebreaker activities, students are asked to open the developer tools and customize the HTML of a webpage for the first time.| After some more icebreaker activities students are asked to cover the history of coding. Students will then complete the necessary ScriptEd paperwork to remain in the course for the year.|
 
 
-##Extra Resources, Challenges and Projects
+## Extra Resources, Challenges and Projects
 [Computer Science Standards Alignment](csStandards.md)
 
 <a href="https://github.com/ScriptEdcurriculum/curriculum2016/wiki/foundationsCourse#unit-0-introductions">ScriptEd Unit 0 Wiki</a> (check this out for additional resources and add your own!)
 
-##Submit Your Feedback
+## Submit Your Feedback
 <a href="https://docs.google.com/forms/d/e/1FAIpQLSfx0wkLyw_jSOhWR2yY8GTR8TV2NXYZc40us7aPHnl9bO6WAQ/viewform">Click here!</a>

--- a/year1/units/unit0/csStandards.md
+++ b/year1/units/unit0/csStandards.md
@@ -1,12 +1,12 @@
-#Unit 1: HTML Content 
+# Unit 1: HTML Content 
 
 
 ## Standards Alignment
 
-####Common Core
+#### Common Core
 **[CCSS.ELA-Literacy.RH.9-10.9](http://www.corestandards.org/ELA-Literacy/RH/9-10/9/)** Compare and contrast treatments of the same topic in several primary and secondary sources.
 
 **[CCSS.MATH.PRACTICE.MP5](http://www.corestandards.org/Math/Practice/#CCSS.Math.Practice.MP5)**: Use appropriate tools strategically.
 
-####CSTA
+#### CSTA
 **CT.L2-03** Define an algorithm as a sequence of instructions that can be processed by a computer.

--- a/year1/units/unit0/topics/topic1/README.md
+++ b/year1/units/unit0/topics/topic1/README.md
@@ -1,4 +1,4 @@
-#Unit 0: Topic 1 || Elements & Icebreakers
+# Unit 0: Topic 1 || Elements & Icebreakers
  ![Imgur](http://i.imgur.com/fq0OEji.png)
  
 | Lesson 1 (45 min) | Lesson 2 (45 min) | 

--- a/year1/units/unit1/README.md
+++ b/year1/units/unit1/README.md
@@ -1,4 +1,4 @@
-#Unit 1: HTML Content 
+# Unit 1: HTML Content 
 
 In this unit students will be introduced to HTML. They will learn tag structure and will use basic tags `<head> <body> <p> <h1> <img> <a>`
 
@@ -24,7 +24,7 @@ In this unit students will be introduced to HTML. They will learn tag structure 
 </table>
 
 
-##Extra Resources, Challenges and Projects
+## Extra Resources, Challenges and Projects
 
 [Common Core & Computer Science Standards Alignment](csStandards.md)
 
@@ -33,5 +33,5 @@ In this unit students will be introduced to HTML. They will learn tag structure 
 
 <a href="https://github.com/ScriptEdcurriculum/curriculum2016/wiki/foundationsCourse#unit-1-html-content">ScriptEd Unit 1 Wiki</a> (check this out for additional resources and add your own!)
 
-##Submit Your Feedback
+## Submit Your Feedback
 <a href="https://docs.google.com/forms/d/e/1FAIpQLSfx0wkLyw_jSOhWR2yY8GTR8TV2NXYZc40us7aPHnl9bO6WAQ/viewform">Click here!</a>

--- a/year1/units/unit1/csStandards.md
+++ b/year1/units/unit1/csStandards.md
@@ -1,16 +1,16 @@
-#Unit 1: HTML Content 
+# Unit 1: HTML Content 
 
 
 ## Standards Alignment
 
-####Common Core
+#### Common Core
 **[CCSS.ELA-Literacy.W.9-10.6](http://www.corestandards.org/ELA-Literacy/W/9-10/2/)** Use technology, including the Internet, to produce, publish, and update individual or shared writing products, taking advantage of technology’s capacity to link to other information and to display information flexibly and dynamically.  
 
 **[CCSS.ELA-Literacy.RH.9-10.9](http://www.corestandards.org/ELA-Literacy/RH/9-10/9/)** Compare and contrast treatments of the same topic in several primary and secondary sources.
 
 **[CCSS.MATH.PRACTICE.MP5](http://www.corestandards.org/Math/Practice/#CCSS.Math.Practice.MP5)**: Use appropriate tools strategically.
 
-####CSTA
+#### CSTA
 **CT.L2-03** Define an algorithm as a sequence of instructions that can be processed by a computer.
 
 **CT.L2-04** Evaluate ways that different algorithms may be used to solve the same problem.

--- a/year1/units/unit1/projects/project1/README.md
+++ b/year1/units/unit1/projects/project1/README.md
@@ -1,14 +1,14 @@
-#Unit 1: Project 1  
-#My First Website
+# Unit 1: Project 1  
+# My First Website
 ![Imgur](http://i.imgur.com/t7nUgLmm.png)
 
-##Scope
+## Scope
 The project for this unit asks the student to create a webpage that includes text, a title, images and links. The students will push their project to GitHub and will finish the unit off with a three question unit challenge.
 
-##Estimated Completion Time
+## Estimated Completion Time
 This project should take one 45 minute period to complete. Projects may take more or less time depending on students' needs.  
 
-##Teacher Pro Tips
+## Teacher Pro Tips
 
 * Today will be the first day to introduce the students to the daily session doc (bit.ly/ScriptEd). The lead teacher must update the document and have students navigate to the link at the beginning of class. 
 
@@ -20,7 +20,7 @@ This project should take one 45 minute period to complete. Projects may take mor
 
 ##[Google Slides](https://docs.google.com/presentation/d/1el_Ohy5n9a6RRTq_hEgtFa0rUUYhJenPrDfVAe3JUWs/edit?usp=sharing)
 
-##Project Extensions
+## Project Extensions
 If students complete this project early, they are encouraged to add a list to their page. Students should be directed to Google "How to make a list in HTML" to do this.
 
 

--- a/year1/units/unit1/topics/topic1/README.md
+++ b/year1/units/unit1/topics/topic1/README.md
@@ -1,5 +1,5 @@
-#Unit 1: Topic 1  
-#Your First Webpage: Basic Tags
+# Unit 1: Topic 1  
+# Your First Webpage: Basic Tags
 ![image](http://i.imgur.com/eqnjBR6.png)
 
 <table>

--- a/year1/units/unit10/README.md
+++ b/year1/units/unit10/README.md
@@ -1,4 +1,4 @@
-#Unit 10: JavaScript: Functions
+# Unit 10: JavaScript: Functions
 
 In this unit students combine their knowledge of **Variables & Functions** to revisit Tiny Turtle to define their own functions. After this they will create new functions for mini-projects.
 <table>
@@ -32,7 +32,7 @@ In this unit students combine their knowledge of **Variables & Functions** to re
 </table>
 
 
-##Extra Resources, Challenges and Projects
+## Extra Resources, Challenges and Projects
 
 
 [Common Core & Computer Science Standards Alignment](csStandards.md)
@@ -40,6 +40,6 @@ In this unit students combine their knowledge of **Variables & Functions** to re
 
 <a href="https://github.com/ScriptEdcurriculum/curriculum2016/wiki/foundationsCourse#unit-10-functions">ScriptEd Unit 10 Wiki</a> (check this out for additional resources and add your own!)
 
-##Submit Your Feedback
+## Submit Your Feedback
 <a href="https://docs.google.com/forms/d/e/1FAIpQLSfx0wkLyw_jSOhWR2yY8GTR8TV2NXYZc40us7aPHnl9bO6WAQ/viewform">Click here!</a>
 

--- a/year1/units/unit10/csStandards.md
+++ b/year1/units/unit10/csStandards.md
@@ -1,9 +1,9 @@
-#Unit 10: Functions
+# Unit 10: Functions
 
 
 ## Standards Alignment
 
-####Common Core
+#### Common Core
 **[CCSS.ELA-Literacy.W.9-10.6](http://www.corestandards.org/ELA-Literacy/W/9-10/2/)** Use technology, including the Internet, to produce, publish, and update individual or shared writing products, taking advantage of technology’s capacity to link to other information and to display information flexibly and dynamically.  
 
 **[CCSS.ELA-Literacy.RH.9-10.9](http://www.corestandards.org/ELA-Literacy/RH/9-10/9/)** Compare and contrast treatments of the same topic in several primary and secondary sources.
@@ -18,7 +18,7 @@
 **[CCSS.MATH.PRACTICE.MP8](http://www.corestandards.org/Math/Practice/#CCSS.Math.Practice.MP8)**: Look for and express regularity in repeated reasoning.
 
 
-####CSTA
+#### CSTA
 **CT.L2-03** Define an algorithm as a sequence of instructions that can be processed by a computer.
 
 **CT.L2-04** Evaluate ways that different algorithms may be used to solve the same problem.

--- a/year1/units/unit10/projects/project1/README.md
+++ b/year1/units/unit10/projects/project1/README.md
@@ -1,13 +1,13 @@
-#Unit 10: Project 1 || Turtle functions
+# Unit 10: Project 1 || Turtle functions
 
 
-##Scope
+## Scope
 In this project students are tasked to create a function with two parameters that can draw any shape the user asks.
 
-##Estimated Completion Time
+## Estimated Completion Time
 <strong>Project 1 is completed during lesson 2. Therefore no extra time needs to be allotted.</strong> 
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * The Tiny Turtle Library requires canvas to be in the head of the page. Do not manipulate this.
 
 
@@ -19,7 +19,7 @@ In this project students are tasked to create a function with two parameters tha
 
 
 
-##Project Extensions
+## Project Extensions
 If students complete this project early, they can be challenges to add a third parameter called `sides` that will generate the amount of sides needed for a shape.
 
 

--- a/year1/units/unit10/projects/project2/README.md
+++ b/year1/units/unit10/projects/project2/README.md
@@ -1,13 +1,13 @@
-#Unit 10: Project 2 || Calculator
+# Unit 10: Project 2 || Calculator
 
 
-##Scope
+## Scope
 This project asks the students to create a calculator with basic functionality. This project provides the student with a lot of solution code. Students will need only to create functions for each calculator action. 
 
-##Estimated Completion Time
+## Estimated Completion Time
 This project should take 45 minutes to complete. Project may take less or more time depending on students' needs.  
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * CStudents should not touch calculator.js... they must only add code to guts.js
 * Stduents have not yet been taught how to create each action. The following unit covers random. This project can be revisited in a couple weeks if the teacher decides they would like to approach it in this way.
 
@@ -19,7 +19,7 @@ This project should take 45 minutes to complete. Project may take less or more t
 
 ##[Google Slides](https://docs.google.com/presentation/d/1fUpLevnu9rBMeFMEdpxlXRNk6yjlaVusHpAggzJjWJo/edit?usp=sharing)
 
-##Project Extensions
+## Project Extensions
 If students complete this project early, they should be encouraged to...
 
 * Add interesting CSS to this project

--- a/year1/units/unit10/topics/topic1/README.md
+++ b/year1/units/unit10/topics/topic1/README.md
@@ -1,4 +1,4 @@
-#Unit 10: Topic 1 || Functions and Parameters
+# Unit 10: Topic 1 || Functions and Parameters
  ![Imgur](http://i.imgur.com/18dWwdS.jpg)
  
 <table>

--- a/year1/units/unit10/topics/topic2/README.md
+++ b/year1/units/unit10/topics/topic2/README.md
@@ -1,4 +1,4 @@
-#Unit 10: Topic 2 || Functions and Parameters
+# Unit 10: Topic 2 || Functions and Parameters
  ![Imgur](http://i.imgur.com/jHwZMgF.png)
  
 <table>

--- a/year1/units/unit11/README.md
+++ b/year1/units/unit11/README.md
@@ -1,4 +1,4 @@
-#Unit 11: JavaScript: Math and Arrays
+# Unit 11: JavaScript: Math and Arrays
 
 In this unit students are introduced to the JavaScript **Math library** in the form of a dice simulation game. After that they will be introduced to **Arrays**.
 <table>
@@ -33,7 +33,7 @@ In this unit students are introduced to the JavaScript **Math library** in the f
 </table>
 
 
-##Extra Resources, Challenges and Projects
+## Extra Resources, Challenges and Projects
 
 * Project: [Random Color Square](projects/projectColorSquare). Extension to earlier project. Great resource! 
 * Project: Magic 8 ball app
@@ -42,6 +42,6 @@ In this unit students are introduced to the JavaScript **Math library** in the f
 
 <a href="https://github.com/ScriptEdcurriculum/curriculum2016/wiki/foundationsCourse#unit-11-math--arrays">ScriptEd Unit 11 Wiki</a> (check this out for additional resources and add your own!)
 
-##Submit Your Feedback
+## Submit Your Feedback
 <a href="https://docs.google.com/forms/d/e/1FAIpQLSfx0wkLyw_jSOhWR2yY8GTR8TV2NXYZc40us7aPHnl9bO6WAQ/viewform">Click here!</a>
 

--- a/year1/units/unit11/csStandards.md
+++ b/year1/units/unit11/csStandards.md
@@ -1,9 +1,9 @@
-#Unit 11: Math and Arrays
+# Unit 11: Math and Arrays
 
 
 ## Standards Alignment
 
-####Common Core
+#### Common Core
 **[CCSS.ELA-Literacy.W.9-10.6](http://www.corestandards.org/ELA-Literacy/W/9-10/2/)** Use technology, including the Internet, to produce, publish, and update individual or shared writing products, taking advantage of technology’s capacity to link to other information and to display information flexibly and dynamically.  
 
 **[CCSS.ELA-Literacy.RH.9-10.9](http://www.corestandards.org/ELA-Literacy/RH/9-10/9/)** Compare and contrast treatments of the same topic in several primary and secondary sources.
@@ -18,7 +18,7 @@
 **[CCSS.MATH.PRACTICE.MP8](http://www.corestandards.org/Math/Practice/#CCSS.Math.Practice.MP8)**: Look for and express regularity in repeated reasoning.
 
 
-####CSTA
+#### CSTA
 **CT.L2-03** Define an algorithm as a sequence of instructions that can be processed by a computer.
 
 **CT.L2-04** Evaluate ways that different algorithms may be used to solve the same problem.

--- a/year1/units/unit11/projects/project1/README.md
+++ b/year1/units/unit11/projects/project1/README.md
@@ -1,13 +1,13 @@
-#Unit 11: Project 1 || Dice Simulator
+# Unit 11: Project 1 || Dice Simulator
 
 
-##Scope
+## Scope
 This project asks the students to create an app that simulates two dice rolling. It requires images to appear on the page that resemble two dies. 
 
-##Estimated Completion Time
+## Estimated Completion Time
 This project should take 90 minutes to complete. Project may take less or more time depending on students' needs.  
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * There are many ways to solve this project. The attached solution code provides a way to do it with the skills that have been taught thus far.
 * Students are asked to work in pairs on this project. The expectation is to collaborate in Cloud 9. However, the teacher may challenge students to collaborate using GitHub pull requests.
 
@@ -19,7 +19,7 @@ This project should take 90 minutes to complete. Project may take less or more t
 
 ##[Google Slides](https://docs.google.com/presentation/d/150mhY3dDnlskIiHNOAmiEu681EU_vBXQ_KwwP0X4H7U/edit#slide=id.g12ee5b58a7_1_0)
 
-##Project Extensions
+## Project Extensions
 If students complete this project early, they should be encouraged to...
 
 * Add interesting CSS to this project

--- a/year1/units/unit11/projects/project2/README.md
+++ b/year1/units/unit11/projects/project2/README.md
@@ -1,13 +1,13 @@
-#Unit 11: Project 2 || The Class Randomizer
+# Unit 11: Project 2 || The Class Randomizer
 
 
-##Scope
+## Scope
 This project asks the students to create a webapp that randomly selects a student and a teacher from the class.
 
-##Estimated Completion Time
+## Estimated Completion Time
 This project should take 45 minutes to complete. Project may take less or more time depending on students' needs.  
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * Students may not know everyone's name. Use this as an opportunity to have everyone formally meet each other.
 * The do now will likely confuse some. However, it is important to make sure EVERY student understands it. 
 
@@ -19,7 +19,7 @@ This project should take 45 minutes to complete. Project may take less or more t
 
 ##[Google Slides](https://docs.google.com/presentation/d/15_PM3BGew-tPXcxOT3Fbbi0uD3cYusw39qn02Lx-okg/edit?usp=sharing)
 
-##Project Extensions
+## Project Extensions
 If students complete this project early, they should be encouraged to...
 
 * Add interesting CSS to this project

--- a/year1/units/unit11/projects/projectColorSquare/README.md
+++ b/year1/units/unit11/projects/projectColorSquare/README.md
@@ -1,13 +1,13 @@
-#Unit 11: Project || Grid Art!
+# Unit 11: Project || Grid Art!
 
 
-##Scope
+## Scope
 This project asks the students to create some random art, using functions and random number generators.
 
-##Estimated Completion Time
+## Estimated Completion Time
 This project should take 45 minutes to complete. Project may take less or more time depending on students' needs.  
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 This project uses functions-- a brief reminder may be needed.
 The solution code doesn't use the random numbers from the previous projects, but you may want to use those.
 
@@ -18,7 +18,7 @@ The solution code doesn't use the random numbers from the previous projects, but
 |[Starter Code](randomsquares-starter.html) | [Solution Code](randomsquares-solution.html) |
 
 
-##Project Extensions
+## Project Extensions
 If students complete this project early, they should be encouraged to...
 
 * Make their own images (smiley faces, etc.)

--- a/year1/units/unit11/topics/topic1/README.md
+++ b/year1/units/unit11/topics/topic1/README.md
@@ -1,4 +1,4 @@
-#Unit 11: Topic 1 || Jeopardy and Math
+# Unit 11: Topic 1 || Jeopardy and Math
  ![Imgur](http://i.imgur.com/Ex7skbmm.png)
  
 <table>

--- a/year1/units/unit11/topics/topic2/README.md
+++ b/year1/units/unit11/topics/topic2/README.md
@@ -1,4 +1,4 @@
-#Unit 11: Topic 2 || Arrays
+# Unit 11: Topic 2 || Arrays
  ![Imgur](http://i.imgur.com/hvHlwejm.png)
  
 <table>

--- a/year1/units/unit12/README.md
+++ b/year1/units/unit12/README.md
@@ -1,4 +1,4 @@
-#Unit 12: JavaScript: Animations and Collisions
+# Unit 12: JavaScript: Animations and Collisions
 
 In this unit students are introduced to the concept of game development as they begin to program simple **Animations & Collision Detections** using jQuery <table>
 <tr>
@@ -21,7 +21,7 @@ In this unit students are introduced to the concept of game development as they 
 </table>
 
 
-##Extra Resources, Challenges and Projects
+## Extra Resources, Challenges and Projects
 
 
 * Project Idea: Falling Snow: Randomly generate elements that fall from the top of the window  
@@ -31,6 +31,6 @@ In this unit students are introduced to the concept of game development as they 
 
 <a href="https://github.com/ScriptEdcurriculum/curriculum2016/wiki/foundationsCourse#unit-12-loops">ScriptEd Unit 12 Wiki</a> (check this out for additional resources and add your own!)
 
-##Submit Your Feedback
+## Submit Your Feedback
 <a href="https://docs.google.com/forms/d/e/1FAIpQLSfx0wkLyw_jSOhWR2yY8GTR8TV2NXYZc40us7aPHnl9bO6WAQ/viewform">Click here!</a>
 

--- a/year1/units/unit12/csStandards.md
+++ b/year1/units/unit12/csStandards.md
@@ -1,8 +1,8 @@
-#Unit 12: Animations and Collisions
+# Unit 12: Animations and Collisions
 
 ## Standards Alignment
 
-####Common Core
+#### Common Core
 **[CCSS.ELA-Literacy.W.9-10.6](http://www.corestandards.org/ELA-Literacy/W/9-10/2/)** Use technology, including the Internet, to produce, publish, and update individual or shared writing products, taking advantage of technology’s capacity to link to other information and to display information flexibly and dynamically.  
 
 **[CCSS.ELA-Literacy.RH.9-10.9](http://www.corestandards.org/ELA-Literacy/RH/9-10/9/)** Compare and contrast treatments of the same topic in several primary and secondary sources.
@@ -17,7 +17,7 @@
 **[CCSS.MATH.PRACTICE.MP8](http://www.corestandards.org/Math/Practice/#CCSS.Math.Practice.MP8)**: Look for and express regularity in repeated reasoning.
 
 
-####CSTA
+#### CSTA
 **CT.L2-03** Define an algorithm as a sequence of instructions that can be processed by a computer.
 
 **CT.L2-04** Evaluate ways that different algorithms may be used to solve the same problem.

--- a/year1/units/unit12/projects/project1/README.md
+++ b/year1/units/unit12/projects/project1/README.md
@@ -1,13 +1,13 @@
-#Unit 12: Project 1 || Falling Object
+# Unit 12: Project 1 || Falling Object
 
 
-##Scope
+## Scope
 This project asks the students to simulate an object "falling". this will require the use of setinterval() and clearInterval() 
 
-##Estimated Completion Time
+## Estimated Completion Time
 This project should should take 2 lessons (90 min) to complete. Project may take more or less time depending on students' needs
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * Students are encouraged to work in pairs. Give a brief reminder on what the driver/GPS relationship looks like in paired programming
 * At one point the students are asked to convert this project from Popcode to GitHub & Cloud9. **Do not skip this step.** At this point in the year all projects must be submitted through Cloud 9 and GitHub. It is a skill the students must learn.
 
@@ -19,7 +19,7 @@ This project should should take 2 lessons (90 min) to complete. Project may take
 
 ##[Google Slides](https://docs.google.com/presentation/d/1hR3-M3sHHgfd3Cd_LTojBBLWLurDr_PTgOgsbmK1TU4/edit#slide=id.g12ee5b58a7_1_0)
 
-##Project Extensions
+## Project Extensions
 If students complete this project early, they should be encouraged to...
 
 * Change or flatten the image when it hits the ground

--- a/year1/units/unit12/topics/topic1/README.md
+++ b/year1/units/unit12/topics/topic1/README.md
@@ -1,4 +1,4 @@
-#Unit 12: Topic 1 || Animations & Collisions
+# Unit 12: Topic 1 || Animations & Collisions
   ![Imgur](http://i.imgur.com/6D3Qcbwm.png)
 <table>
 <tr>

--- a/year1/units/unit13/README.md
+++ b/year1/units/unit13/README.md
@@ -1,4 +1,4 @@
-#Unit 13: JavaScript: Loops
+# Unit 13: JavaScript: Loops
 
 In this unit students will be introduced to **For Loops.** They will generate images rapidly on an HTML page and will then revisit Tiny Turtle to create fractal art programs.
 <table>
@@ -26,7 +26,7 @@ In this unit students will be introduced to **For Loops.** They will generate im
 </table>
 
 
-##Extra Resources, Challenges and Projects
+## Extra Resources, Challenges and Projects
 
 
 
@@ -35,6 +35,6 @@ In this unit students will be introduced to **For Loops.** They will generate im
 
 <a href="https://github.com/ScriptEdcurriculum/curriculum2016/wiki/foundationsCourse#unit-13-animations-and-collisions">ScriptEd Unit 13 Wiki</a> (check this out for additional resources and add your own!)
 
-##Submit Your Feedback
+## Submit Your Feedback
 <a href="https://docs.google.com/forms/d/e/1FAIpQLSfx0wkLyw_jSOhWR2yY8GTR8TV2NXYZc40us7aPHnl9bO6WAQ/viewform">Click here!</a>
 

--- a/year1/units/unit13/csStandards.md
+++ b/year1/units/unit13/csStandards.md
@@ -1,9 +1,9 @@
-#Unit 13: Looping
+# Unit 13: Looping
 
 
 ## Standards Alignment
 
-####Common Core
+#### Common Core
 **[CCSS.ELA-Literacy.W.9-10.6](http://www.corestandards.org/ELA-Literacy/W/9-10/2/)** Use technology, including the Internet, to produce, publish, and update individual or shared writing products, taking advantage of technology’s capacity to link to other information and to display information flexibly and dynamically.  
 
 **[CCSS.ELA-Literacy.RST.9-10.3](http://www.corestandards.org/ELA-Literacy/RST/9-10/3/)** Follow precisely a complex multistep procedure when carrying out experiments, taking measurements, or performing technical tasks, attending to special cases or exceptions defined in the text.
@@ -16,7 +16,7 @@
 **[CCSS.MATH.PRACTICE.MP8](http://www.corestandards.org/Math/Practice/#CCSS.Math.Practice.MP8)**: Look for and express regularity in repeated reasoning.
 
 
-####CSTA
+#### CSTA
 **CT.L2-03** Define an algorithm as a sequence of instructions that can be processed by a computer.
 
 **CT.L2-04** Evaluate ways that different algorithms may be used to solve the same problem.

--- a/year1/units/unit13/projects/project1/README.md
+++ b/year1/units/unit13/projects/project1/README.md
@@ -1,13 +1,13 @@
-#Unit 13: Project 1 || Turtle Fractal Art
+# Unit 13: Project 1 || Turtle Fractal Art
 ![Imgur](http://i.imgur.com/lcFUk0nm.png)
 
-##Scope
+## Scope
 This project asks the students to visit tiny turtle for the last time. They will creating fractal art using for loops that direct the turtle.
 
-##Estimated Completion Time
+## Estimated Completion Time
 This project should can take 1-2 classes. If the students are given specific task to work towards such as draw a flower this project can be extremely engaging. Teacher should use their discretion as to how long this project should last. 
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * Provide students with goals. Create a ___ that looks like ____.
 * Tie loops back into earlier concepts learned in Tiny turtle such at functions.
 
@@ -19,7 +19,7 @@ This project should can take 1-2 classes. If the students are given specific tas
 
 ##[Google Slides](https://docs.google.com/presentation/d/1huJQr2YQW6vYh-4sHb61XuK617b0cM-DaqS6wPYg9V0/edit?usp=sharing)
 
-##Project Extensions
+## Project Extensions
 If students complete this project early, they should be encouraged to...
 
 * Change some of the documentation in the tiny turtle library for added customization.

--- a/year1/units/unit13/projects/project2/README.md
+++ b/year1/units/unit13/projects/project2/README.md
@@ -1,13 +1,13 @@
-#Unit 12: Project 2 || Hangman
+# Unit 12: Project 2 || Hangman
 
 
-##Scope
+## Scope
 This project asks the students to create a fully functioning Hangman game.
 
-##Estimated Completion Time
+## Estimated Completion Time
 This project should take 270 minutes to complete. Project may take less or more time depending on students' needs.  
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * **This project is extremely challenging! It is at the team's discretion whether or not they should skip over this project and possibly return to it later.**
 * Not all student will know what Hangman is. Expect to explain this in the first class
 * A step may take less or more than one class. Be prepared to work through this at your class's necessary pace.
@@ -29,7 +29,7 @@ This project includes detailed guided docs that could be useful for anyone leadi
 
 ##[Google Slides](https://docs.google.com/presentation/d/1yaBx7PiRJ0egSAkfovDht8uVWjyyU8aDo8ZtzWUfjSs/edit?usp=sharing)
 
-##Project Extensions
+## Project Extensions
 If students complete this project early, they should be encouraged to...
 
 * Add a feature that shows a bank of already used letters

--- a/year1/units/unit13/topics/topic1/README.md
+++ b/year1/units/unit13/topics/topic1/README.md
@@ -1,4 +1,4 @@
-#Unit 13: Topic 1 || For loops
+# Unit 13: Topic 1 || For loops
  
 
  ![Imgur](http://i.imgur.com/UAzbumwt.jpg) ![Imgur](http://i.imgur.com/UAzbumwt.jpg) ![Imgur](http://i.imgur.com/UAzbumwt.jpg)

--- a/year1/units/unit14/README.md
+++ b/year1/units/unit14/README.md
@@ -1,4 +1,4 @@
-#Unit 14: Capstone Project
+# Unit 14: Capstone Project
 
 Students will be compiling all their knowledge from the year in a final project which resembles a "space invaders" style game. Students will be broken up into groups of 2-3
 
@@ -17,12 +17,12 @@ Students will be compiling all their knowledge from the year in a final project 
 </table>
 
 
-##Extra Resources, Challenges and Projects
+## Extra Resources, Challenges and Projects
 
 [Common Core & Computer Science Standards Alignment](csStandards.md)
 
 <a href="https://github.com/ScriptEdcurriculum/curriculum2016/wiki/foundationsCourse#unit-14-capstone-project">ScriptEd Unit 14 Wiki</a> (check this out for additional resources and add your own!)
 
-##Submit Your Feedback
+## Submit Your Feedback
 <a href="https://docs.google.com/forms/d/e/1FAIpQLSfx0wkLyw_jSOhWR2yY8GTR8TV2NXYZc40us7aPHnl9bO6WAQ/viewform">Click here!</a>
 

--- a/year1/units/unit14/csStandards.md
+++ b/year1/units/unit14/csStandards.md
@@ -1,9 +1,9 @@
-#Unit 14: Capstone Project
+# Unit 14: Capstone Project
 
 
 ## Standards Alignment
 
-####Common Core
+#### Common Core
 **[CCSS.ELA-Literacy.W.9-10.6](http://www.corestandards.org/ELA-Literacy/W/9-10/2/)** Use technology, including the Internet, to produce, publish, and update individual or shared writing products, taking advantage of technology’s capacity to link to other information and to display information flexibly and dynamically.  
 
 **[CCSS.ELA-Literacy.RH.9-10.9](http://www.corestandards.org/ELA-Literacy/RH/9-10/9/)** Compare and contrast treatments of the same topic in several primary and secondary sources.
@@ -18,7 +18,7 @@
 **[CCSS.MATH.PRACTICE.MP8](http://www.corestandards.org/Math/Practice/#CCSS.Math.Practice.MP8)**: Look for and express regularity in repeated reasoning.
 
 
-####CSTA
+#### CSTA
 **CT.L2-03** Define an algorithm as a sequence of instructions that can be processed by a computer.
 
 **CT.L2-04** Evaluate ways that different algorithms may be used to solve the same problem.

--- a/year1/units/unit14/projects/project1/README.md
+++ b/year1/units/unit14/projects/project1/README.md
@@ -1,13 +1,13 @@
-#Unit 14: Capstone Project
+# Unit 14: Capstone Project
 
 
-##Scope
+## Scope
 Students will be compiling all their knowledge from the year in a final project which resembles a "space invaders" style game. Students will be broken up into groups of 2-3
 
-##Estimated Completion Time
+## Estimated Completion Time
 This project should should take 6 lessons (270 min) to complete. Project may take more or less time depending on students' needs
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * This project will span several classes. It is important to start off each day with a do now and end each day with a scrum. This keeps everyone focused.
 * Students often set unrealistic daily goals. Encourage them to break up goals in to very small, attainable tasks.
 * To save time, Scrums can be completed in small groups with one volunteer assigned to each scrum.
@@ -20,7 +20,7 @@ This project should should take 6 lessons (270 min) to complete. Project may tak
 
 ##[Google Slides](https://docs.google.com/presentation/d/1NvnX1AlpYzmjqVpwc7EijRoLsguq0ytX1E2XxwPqhSI/edit#slide=id.g12ee5b58a7_1_0)
 
-##Project Extensions
+## Project Extensions
 Students are encouraged to be endlessly creative in this project. Examples of ways to improve this project are...
 
 * create a win/lose feature

--- a/year1/units/unit2/README.md
+++ b/year1/units/unit2/README.md
@@ -1,4 +1,4 @@
-#Unit 2: CSS Tag Selectors 
+# Unit 2: CSS Tag Selectors 
 
 In this unit students will be taught how to manipulate the style of a webpage using basic CSS selectors.
 
@@ -23,7 +23,7 @@ In this unit students will be taught how to manipulate the style of a webpage us
 </table>
 
 
-##Extra Resources, Challenges and Projects
+## Extra Resources, Challenges and Projects
 [Common Core & Computer Science Standards Alignment](csStandards.md)
 
 [Find A favorite Google Font and Use It In Popcode](google-fonts-activity.md)
@@ -31,5 +31,5 @@ In this unit students will be taught how to manipulate the style of a webpage us
 
 <a href="https://github.com/ScriptEdcurriculum/curriculum2016/wiki/foundationsCourse#unit-2-css-tag-selectors">ScriptEd Unit 2 Wiki</a> (check this out for additional resources and add your own!)
 
-##Submit Your Feedback
+## Submit Your Feedback
 <a href="https://docs.google.com/forms/d/e/1FAIpQLSfx0wkLyw_jSOhWR2yY8GTR8TV2NXYZc40us7aPHnl9bO6WAQ/viewform">Click here!</a>

--- a/year1/units/unit2/csStandards.md
+++ b/year1/units/unit2/csStandards.md
@@ -1,14 +1,14 @@
-#Unit 2: CSS Tag Selectors
+# Unit 2: CSS Tag Selectors
 
 
 ## Standards Alignment
 
-####Common Core
+#### Common Core
 **[CCSS.ELA-Literacy.W.9-10.6](http://www.corestandards.org/ELA-Literacy/W/9-10/2/)** Use technology, including the Internet, to produce, publish, and update individual or shared writing products, taking advantage of technology’s capacity to link to other information and to display information flexibly and dynamically.  
 
 **[CCSS.MATH.PRACTICE.MP5](http://www.corestandards.org/Math/Practice/#CCSS.Math.Practice.MP5)**: Use appropriate tools strategically.
 
-####CSTA
+#### CSTA
 **CT.L2-03** Define an algorithm as a sequence of instructions that can be processed by a computer.
 
 **CT.L2-04** Evaluate ways that different algorithms may be used to solve the same problem.

--- a/year1/units/unit2/projects/project1/README.md
+++ b/year1/units/unit2/projects/project1/README.md
@@ -1,10 +1,10 @@
-#Unit 2: Project 1 || About Who?
+# Unit 2: Project 1 || About Who?
 ![image](https://i.imgur.com/UfBwSzcl.jpg)
 
-##Scope
+## Scope
 The project for this unit asks the student to create a webpage for someone else in their ScriptEd class. The students will use their knowledge of CSS and branding to create the best website for their friend. The students will then push their project to GitHub.
 
-##Estimated Completion Time
+## Estimated Completion Time
 This project should take 90 minutes to complete. Project may take less or more time depending on students' needs.  
 
 
@@ -16,7 +16,7 @@ This project should take 90 minutes to complete. Project may take less or more t
 
 ##[Google Slides](https://docs.google.com/presentation/d/1vGQf6Ksp-oSNRH-cHpCkGtl__xhn7wv1cW4lIUf-piI/edit?usp=sharing)
 
-##Project Extensions
+## Project Extensions
 If students complete this project early, they are encouraged to attempt to position elements strategically around the page. They will have to Search using Google to learn how to do this.
 
 

--- a/year1/units/unit2/topics/topic1/README.md
+++ b/year1/units/unit2/topics/topic1/README.md
@@ -1,4 +1,4 @@
-#Unit 2: Topic 1 || CSS Basic Tags
+# Unit 2: Topic 1 || CSS Basic Tags
  ![Imgur](http://i.imgur.com/PH8Qb8y.jpg)
  
 <table>

--- a/year1/units/unit3/README.md
+++ b/year1/units/unit3/README.md
@@ -1,4 +1,4 @@
-#Unit 3: HTML Lists, Classes & IDs 
+# Unit 3: HTML Lists, Classes & IDs 
 
 In this unit students will first learn how to make ordered and unordered lists. They will then utilize IDs and Classes to identify tags on a webpage.
 
@@ -28,12 +28,12 @@ In this unit students will first learn how to make ordered and unordered lists. 
 
 
 
-##Extra Resources, Challenges and Projects
+## Extra Resources, Challenges and Projects
 [Common Core & Computer Science Standards Alignment](csStandards.md)
 
 <a href="https://github.com/ScriptEdcurriculum/curriculum2016/wiki/foundationsCourse#unit-3-html-lists-ids--classes">ScriptEd Unit 3 Wiki</a> (check this out for additional resources and add your own!)
 
-##Submit your feedback
+## Submit your feedback
 <a href="https://docs.google.com/forms/d/e/1FAIpQLSfx0wkLyw_jSOhWR2yY8GTR8TV2NXYZc40us7aPHnl9bO6WAQ/viewform">Click here!</a>
 
 

--- a/year1/units/unit3/csStandards.md
+++ b/year1/units/unit3/csStandards.md
@@ -1,16 +1,16 @@
-#Unit 3: Lists, IDs & Classes
+# Unit 3: Lists, IDs & Classes
 
 
 ## Standards Alignment
 
-####Common Core
+#### Common Core
 **[CCSS.ELA-Literacy.W.9-10.6](http://www.corestandards.org/ELA-Literacy/W/9-10/2/)** Use technology, including the Internet, to produce, publish, and update individual or shared writing products, taking advantage of technology’s capacity to link to other information and to display information flexibly and dynamically.  
 
 **[CCSS.ELA-Literacy.RH.9-10.9](http://www.corestandards.org/ELA-Literacy/RH/9-10/9/)** Compare and contrast treatments of the same topic in several primary and secondary sources.
 
 **[CCSS.MATH.PRACTICE.MP5](http://www.corestandards.org/Math/Practice/#CCSS.Math.Practice.MP5)**: Use appropriate tools strategically.
 
-####CSTA
+#### CSTA
 **CT.L2-03** Define an algorithm as a sequence of instructions that can be processed by a computer.
 
 **CT.L2-04** Evaluate ways that different algorithms may be used to solve the same problem.

--- a/year1/units/unit3/projects/project1/README.md
+++ b/year1/units/unit3/projects/project1/README.md
@@ -1,14 +1,14 @@
-#Unit 3: Project 1 ||General Assembly Tutorial
+# Unit 3: Project 1 ||General Assembly Tutorial
 ![Imgur](http://i.imgur.com/t1O7Zcjm.jpg)
 
-##Scope
+## Scope
 The project for this unit is a tutorial made by General Assembly. This tutorial is a self-guided set of step-by-step instructions that will reinforce student learning on concepts being taught in class.
 
 
-##Estimated Completion Time
+## Estimated Completion Time
 This project should take 90 minutes to complete. Projects may take less or more time depending on students' needs.  
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * **Before class begins** 1 copy of the [GA Tutorial Worksheet](https://www.dropbox.com/s/x7kyti0jt6easj0/GeneralAssemblyPacketJeffBlog.docx ) must be printed for each student.
 * Completing this project can be assigned to students for homework or during class on a day ScriptEd volunteers are not present.
 * Encourage students to customize the website to be personal to them.
@@ -22,7 +22,7 @@ This project should take 90 minutes to complete. Projects may take less or more 
 
 ##[Google Slides](https://docs.google.com/presentation/d/150yZStV8RYMswp0Z8aIR-4jHjIkv9kjMXCAbkMjBV48/edit?usp=sharing)
 
-##Project Extensions
+## Project Extensions
 If students complete this project early, they are encouraged to copy and paste the code into Popcode and customize the site to be more personalized to them.
 
 

--- a/year1/units/unit3/topics/topic1/README.md
+++ b/year1/units/unit3/topics/topic1/README.md
@@ -1,4 +1,4 @@
-#Unit 3: Topic 1 || HTML Lists
+# Unit 3: Topic 1 || HTML Lists
  ![Imgur](http://i.imgur.com/0fWa0jv.gif)
  
 <table>

--- a/year1/units/unit3/topics/topic2/README.md
+++ b/year1/units/unit3/topics/topic2/README.md
@@ -1,4 +1,4 @@
-#Unit 3: Topic 2 || Classes, IDs & Divs
+# Unit 3: Topic 2 || Classes, IDs & Divs
  ![Imgur](http://i.imgur.com/DuOsNAP.jpg)
  
 <table>

--- a/year1/units/unit4/README.md
+++ b/year1/units/unit4/README.md
@@ -1,4 +1,4 @@
-#Unit 4: Positioning, Layout and Wireframing 
+# Unit 4: Positioning, Layout and Wireframing 
 
 In this unit students will learn how to manipulate the look and feel of a webpage using CSS. Until this point, all pages the students have created are aligned to the left of the page and each element has its own row. In this unit students will be introduced to properties that allow for greater visual manipulation.  
 
@@ -33,12 +33,12 @@ In this unit students will learn how to manipulate the look and feel of a webpag
 </table>
 
 
-##Extra Resources, Challenges and Projects
+## Extra Resources, Challenges and Projects
 [Common Core & Computer Science Standards Alignment](csStandards.md)
 
 <a href="https://github.com/ScriptEdcurriculum/curriculum2016/wiki/foundationsCourse#unit-4-positioning-layout--wireframing">ScriptEd Unit 4 Wiki</a> (check this out for additional resources and add your own!)
 
-##Submit your feedback
+## Submit your feedback
 <a href="https://docs.google.com/forms/d/e/1FAIpQLSfx0wkLyw_jSOhWR2yY8GTR8TV2NXYZc40us7aPHnl9bO6WAQ/viewform">Click here!</a>
 
 

--- a/year1/units/unit4/csStandards.md
+++ b/year1/units/unit4/csStandards.md
@@ -1,9 +1,9 @@
-#Unit 4: Positioning and Layout
+# Unit 4: Positioning and Layout
 
 
 ## Standards Alignment
 
-####Common Core
+#### Common Core
 **[CCSS.ELA-Literacy.W.9-10.6](http://www.corestandards.org/ELA-Literacy/W/9-10/2/)** Use technology, including the Internet, to produce, publish, and update individual or shared writing products, taking advantage of technology’s capacity to link to other information and to display information flexibly and dynamically.  
 
 **[CCSS.ELA-Literacy.RH.9-10.9](http://www.corestandards.org/ELA-Literacy/RH/9-10/9/)** Compare and contrast treatments of the same topic in several primary and secondary sources.
@@ -13,7 +13,7 @@
 **[CCSS.MATH.PRACTICE.MP8](http://www.corestandards.org/Math/Practice/#CCSS.Math.Practice.MP8)**: Look for and express regularity in repeated reasoning.
 
 
-####CSTA
+#### CSTA
 
 **CPP.L2-03**
 

--- a/year1/units/unit4/projects/project1/README.md
+++ b/year1/units/unit4/projects/project1/README.md
@@ -1,14 +1,14 @@
-#Unit 4: Project 1 || ScriptEd CSS Garden
+# Unit 4: Project 1 || ScriptEd CSS Garden
 
 
-##Scope
+## Scope
 The first project in this unit asks the students to take the provided HTML [Starter Code](https://popcode.org/?gist=00dec2d499df0019b76afd804b4772a7) and design CSS for it. The students are required to not edit the HTML in any way. 
 
 
-##Estimated Completion Time
+## Estimated Completion Time
 This project should take 90 minutes to complete (45 minutes of work time & 45 minutes of presentations). Project may take less or more time depending on students' needs.  
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * It is encouraged that the teachers in the class complete this project and show off their final product to the class before they get started
 * Students must work in pairs and present their work. This will help build professional skills.
 
@@ -20,7 +20,7 @@ This project should take 90 minutes to complete (45 minutes of work time & 45 mi
 
 ##[Google Slides](https://docs.google.com/presentation/d/1_SDEEjl2-rxSspK5AWUfRXy6Z9TqCpx0ssWkybGPBeE/edit?usp=sharing)
 
-##Project Extensions
+## Project Extensions
 If students complete this project early, they are encouraged to customize this site so that it is mobile friendly. As a note, responsive websites will be the next topic covered.
 
 

--- a/year1/units/unit4/projects/project2/README.md
+++ b/year1/units/unit4/projects/project2/README.md
@@ -1,13 +1,13 @@
-#Unit 4: Project 2 || CSS Zen Garden
+# Unit 4: Project 2 || CSS Zen Garden
 
 
-##Scope
+## Scope
 This project asks the students to work in pairs to compete in  the online design competition called <a href="https://www.csszengarden.com/">CSS Zen Garden</a>.
 
-##Estimated Completion Time
+## Estimated Completion Time
 This project should take 90 minutes to complete. Project may take less or more time depending on students' needs.  
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * This project involves an overwhelming amount of starter code. If you feel your students need direction getting started use [this resource](https://docs.google.com/document/d/1wDWWz-9vdT2gH4S8lvTfhg8g2mfid9DbyW6l51bC21E/edit).
 * It is encouraged that the teachers in the class complete this project and show off their final product to the class before they get started.
 * Students must work in pairs and present their work. This will help build professional skills.
@@ -20,7 +20,7 @@ This project should take 90 minutes to complete. Project may take less or more t
 
 ##[Google Slides](https://docs.google.com/presentation/d/16XxbPKe53wUsFqlqbRXADzlhGL7ferB-qwSnPkmmp6U/edit?usp=sharing)
 
-##Project Extensions
+## Project Extensions
 This project can never be complete :) CSS/Design is a process of continuous improvement!
 
 

--- a/year1/units/unit4/topics/topic1/README.md
+++ b/year1/units/unit4/topics/topic1/README.md
@@ -1,4 +1,4 @@
-#Unit 4: Topic 1 || CSS Positioning
+# Unit 4: Topic 1 || CSS Positioning
  ![Imgur](https://i.imgur.com/ghMzqaf.png)
  
 <table>

--- a/year1/units/unit4/topics/topic2/README.md
+++ b/year1/units/unit4/topics/topic2/README.md
@@ -1,4 +1,4 @@
-#Unit 4: Topic 2 ||  Wireframing
+# Unit 4: Topic 2 ||  Wireframing
 ![Imgur](http://i.imgur.com/hwLWyaBm.png) 
 
 <table>

--- a/year1/units/unit5/README.md
+++ b/year1/units/unit5/README.md
@@ -1,4 +1,4 @@
-#Unit 5: jQuery
+# Unit 5: jQuery
 
 In this unit students are introduced to jQuery. jQuery is used as a tool for creating interactive websites that react to user actions.
 
@@ -34,14 +34,14 @@ In this unit students are introduced to jQuery. jQuery is used as a tool for cre
 </table>
 
 
-##Extra Resources, Challenges and Projects
+## Extra Resources, Challenges and Projects
 **Project:** [Do you love ScriptEd?](https://popcode.org/?gist=0b45fb64254646f993da2804b691a497) This can be completed with topic 1 skills only
 
 [Common Core & Computer Science Standards Alignment](csStandards.md)
 
 <a href="https://github.com/ScriptEdcurriculum/curriculum2016/wiki/foundationsCourse#unit-5-jquery">ScriptEd Unit 5 Wiki</a> (check this out for additional resources and add your own!)
 
-##Submit Your Feedback
+## Submit Your Feedback
 <a href="https://docs.google.com/forms/d/e/1FAIpQLSfx0wkLyw_jSOhWR2yY8GTR8TV2NXYZc40us7aPHnl9bO6WAQ/viewform">Click here!</a>
 
 

--- a/year1/units/unit5/csStandards.md
+++ b/year1/units/unit5/csStandards.md
@@ -1,9 +1,9 @@
-#Unit 5: jQuery
+# Unit 5: jQuery
 
 
 ## Standards Alignment
 
-####Common Core
+#### Common Core
 **[CCSS.ELA-Literacy.W.9-10.6](http://www.corestandards.org/ELA-Literacy/W/9-10/2/)** Use technology, including the Internet, to produce, publish, and update individual or shared writing products, taking advantage of technology’s capacity to link to other information and to display information flexibly and dynamically.  
 
 **[CCSS.ELA-Literacy.RH.9-10.9](http://www.corestandards.org/ELA-Literacy/RH/9-10/9/)** Compare and contrast treatments of the same topic in several primary and secondary sources.
@@ -17,7 +17,7 @@
 **[CCSS.MATH.PRACTICE.MP8](http://www.corestandards.org/Math/Practice/#CCSS.Math.Practice.MP8)**: Look for and express regularity in repeated reasoning.
 
 
-####CSTA
+#### CSTA
 
 **CPP.L2-03**
 

--- a/year1/units/unit5/projects/project1/README.md
+++ b/year1/units/unit5/projects/project1/README.md
@@ -1,14 +1,14 @@
-#Unit 5: Project 1 || Pun-A-Thon
+# Unit 5: Project 1 || Pun-A-Thon
 
 
-##Scope
+## Scope
 This activity asks the students to complete a project that is unfinished using jQuery events.
 
 
-##Estimated Completion Time
+## Estimated Completion Time
 This project should take 30-40 minutes to complete. Projects may take less or more time depending on students' needs.  
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * It is encouraged to show off the project's solution code before having the students begin in order for them to understand where the project is going.
 
 <br>
@@ -19,7 +19,7 @@ This project should take 30-40 minutes to complete. Projects may take less or mo
 
 ##[Google Slides](https://docs.google.com/presentation/d/1WF-V39WIfWG8kuhNrD7L0Mx7Dyh3aZjd9-_u2rQMWZ8/edit?usp=sharing)
 
-##Project Extensions
+## Project Extensions
 If students complete this project early, the comments in the code ask for the student to create buttons that will initiate the events.
 
 

--- a/year1/units/unit5/projects/project2/README.md
+++ b/year1/units/unit5/projects/project2/README.md
@@ -1,13 +1,13 @@
-#Unit 5: Project 2 || jQuery Fun House
+# Unit 5: Project 2 || jQuery Fun House
 
 
-##Scope
+## Scope
 This project asks the students to create a site that uses all the skills they have learned thus far with jQuery. This includes click handlers, retrieving a value and changing an attribute.
 
-##Estimated Completion Time
+## Estimated Completion Time
 This project should take 90 minutes to complete. Project may take less or more time depending on students' needs.  
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * Show off the solution project before starting. Deployable link found [here](https://outoftime.github.io/jqWestinghouse/)
 * There are several ways to complete this project. The simpliest way is expected. Completing this project does not require any further skills than what is expected.
 
@@ -19,7 +19,7 @@ This project should take 90 minutes to complete. Project may take less or more t
 
 ##[Google Slides](https://docs.google.com/presentation/d/1rCVCIqXSNU7N2zfZuuD6APR5BQMoqs4rKFL5dz4EAmw/edit?usp=sharing)
 
-##Project Extensions
+## Project Extensions
 
 * Students that complete early may add styles and more functionality to this site.
 * If a student is up for a challenge they could be asked to research the concept of "this" and implement it on their site. 

--- a/year1/units/unit5/topics/topic1/README.md
+++ b/year1/units/unit5/topics/topic1/README.md
@@ -1,4 +1,4 @@
-#Unit 5: Topic 1 || Intro to Programming
+# Unit 5: Topic 1 || Intro to Programming
  ![Imgur](http://i.imgur.com/pV3BGBg.jpg)
  
 <table>

--- a/year1/units/unit5/topics/topic2/README.md
+++ b/year1/units/unit5/topics/topic2/README.md
@@ -1,4 +1,4 @@
-#Unit 5: Topic 2 ||  Value and Syntax
+# Unit 5: Topic 2 ||  Value and Syntax
 ![Imgur](http://i.imgur.com/KwaFtIPm.png)
 
 <table>

--- a/year1/units/unit6/README.md
+++ b/year1/units/unit6/README.md
@@ -1,4 +1,4 @@
-#Unit 6: Cloud 9, GitHub & Multi-Page Sites 
+# Unit 6: Cloud 9, GitHub & Multi-Page Sites 
 
 In this unit students will be introduced to a new IDE called Cloud 9. They will then create a project using Cloud 9 and GitHub using skills they have already gained in previous units.
 
@@ -26,13 +26,13 @@ In this unit students will be introduced to a new IDE called Cloud 9. They will 
 </table>
 
 
-##Extra Resources, Challenges and Projects
+## Extra Resources, Challenges and Projects
 
 
 [Common Core & Computer Science Standards Alignment](csStandards.md)
 
 <a href="https://github.com/ScriptEdcurriculum/curriculum2016/wiki/foundationsCourse#unit-6-cloud-9--multi-page-sites">ScriptEd Unit 6 Wiki</a> (check this out for additional resources and add your own!)
 
-##Submit Your Feedback
+## Submit Your Feedback
 <a href="https://docs.google.com/forms/d/e/1FAIpQLSfx0wkLyw_jSOhWR2yY8GTR8TV2NXYZc40us7aPHnl9bO6WAQ/viewform">Click here!</a>
 

--- a/year1/units/unit6/csStandards.md
+++ b/year1/units/unit6/csStandards.md
@@ -1,8 +1,8 @@
-#Unit 6: Cloud 9, Git & Multi-page sites
+# Unit 6: Cloud 9, Git & Multi-page sites
 
 ## Standards Alignment
 
-####Common Core
+#### Common Core
 **[CCSS.ELA-Literacy.W.9-10.6](http://www.corestandards.org/ELA-Literacy/W/9-10/2/)** Use technology, including the Internet, to produce, publish, and update individual or shared writing products, taking advantage of technology’s capacity to link to other information and to display information flexibly and dynamically.  
 
 **[CCSS.ELA-Literacy.RH.9-10.9](http://www.corestandards.org/ELA-Literacy/RH/9-10/9/)** Compare and contrast treatments of the same topic in several primary and secondary sources.
@@ -12,7 +12,7 @@
 **[CCSS.MATH.PRACTICE.MP5](http://www.corestandards.org/Math/Practice/#CCSS.Math.Practice.MP5)**: Use appropriate tools strategically.
 
 
-####CSTA
+#### CSTA
 **CT.L2-03** Define an algorithm as a sequence of instructions that can be processed by a computer.
 
 **CT.L2-04** Evaluate ways that different algorithms may be used to solve the same problem.

--- a/year1/units/unit6/topics/topic1/README.md
+++ b/year1/units/unit6/topics/topic1/README.md
@@ -1,4 +1,4 @@
-#Unit 6: Topic 1 || Cloud 9 and GitHub
+# Unit 6: Topic 1 || Cloud 9 and GitHub
  ![Imgur](http://i.imgur.com/jN4HZ6x.png)
  
 <table>

--- a/year1/units/unit6/topics/topic2/README.md
+++ b/year1/units/unit6/topics/topic2/README.md
@@ -1,4 +1,4 @@
-#Unit 6: Topic 2 ||  Multi-Page Sites
+# Unit 6: Topic 2 ||  Multi-Page Sites
 ![Imgur](http://i.imgur.com/3u4PxqRm.png)
 <table>
 <tr>

--- a/year1/units/unit7/README.md
+++ b/year1/units/unit7/README.md
@@ -1,4 +1,4 @@
-#Unit 7: GitHub Collaboration 
+# Unit 7: GitHub Collaboration 
 
 In this unit the class will collaborate on a project using GitHub and Cloud 9.
 
@@ -20,14 +20,14 @@ In this unit the class will collaborate on a project using GitHub and Cloud 9.
 </table>
 
 
-##Extra Resources, Challenges and Projects
+## Extra Resources, Challenges and Projects
 **Project:** [Portfolio Collaboration](https://github.com/Bijesse/scripted-student-portfolios) In this project the class creates a landing page for all their portfolios. 
 
 [Common Core & Computer Science Standards Alignment](csStandards.md)
 
 <a href="https://github.com/ScriptEdcurriculum/curriculum2016/wiki/foundationsCourse#unit-7-github-collaboration">ScriptEd Unit 7 Wiki</a> (check this out for additional resources and add your own!)
 
-##Submit Your Feedback
+## Submit Your Feedback
 <a href="https://docs.google.com/forms/d/e/1FAIpQLSfx0wkLyw_jSOhWR2yY8GTR8TV2NXYZc40us7aPHnl9bO6WAQ/viewform">Click here!</a>
 
 

--- a/year1/units/unit7/csStandards.md
+++ b/year1/units/unit7/csStandards.md
@@ -1,9 +1,9 @@
-#Unit 7: GitHub Collaboration
+# Unit 7: GitHub Collaboration
 
 
 ## Standards Alignment
 
-####Common Core
+#### Common Core
 **[CCSS.ELA-Literacy.W.9-10.6](http://www.corestandards.org/ELA-Literacy/W/9-10/2/)** Use technology, including the Internet, to produce, publish, and update individual or shared writing products, taking advantage of technology’s capacity to link to other information and to display information flexibly and dynamically.  
 
 **[CCSS.ELA-Literacy.RST.9-10.3](http://www.corestandards.org/ELA-Literacy/RST/9-10/3/)** Follow precisely a complex multistep procedure when carrying out experiments, taking measurements, or performing technical tasks, attending to special cases or exceptions defined in the text.
@@ -15,7 +15,7 @@
 **[CCSS.MATH.PRACTICE.MP8](http://www.corestandards.org/Math/Practice/#CCSS.Math.Practice.MP8)**: Look for and express regularity in repeated reasoning.
 
 
-####CSTA
+#### CSTA
 **CT.L2-03** Define an algorithm as a sequence of instructions that can be processed by a computer.
 
 **CT.L2-04** Evaluate ways that different algorithms may be used to solve the same problem.

--- a/year1/units/unit7/topics/topic1/README.md
+++ b/year1/units/unit7/topics/topic1/README.md
@@ -1,4 +1,4 @@
-#Unit 7: Topic 1 || Mr. Potato Head
+# Unit 7: Topic 1 || Mr. Potato Head
  ![Imgur](http://i.imgur.com/Vy06FW3.gif)
   
 <table>

--- a/year1/units/unit8/README.md
+++ b/year1/units/unit8/README.md
@@ -1,4 +1,4 @@
-#Unit 8: JavaScript Introduction
+# Unit 8: JavaScript Introduction
 
 In this unit the students will be introduced to JavaScript functions using a visual JavaScript library.
 
@@ -25,13 +25,13 @@ In this unit the students will be introduced to JavaScript functions using a vis
 </table>
 
 
-##Extra Resources, Challenges and Projects
+## Extra Resources, Challenges and Projects
 
 
 [Common Core & Computer Science Standards Alignment](csStandards.md)
 
 <a href="https://github.com/ScriptEdcurriculum/curriculum2016/wiki/foundationsCourse#unit-8-javascript-introductions">ScriptEd Unit 8 Wiki</a> (check this out for additional resources and add your own!)
 
-##Submit Your Feedback
+## Submit Your Feedback
 <a href="https://docs.google.com/forms/d/e/1FAIpQLSfx0wkLyw_jSOhWR2yY8GTR8TV2NXYZc40us7aPHnl9bO6WAQ/viewform">Click here!</a>
 

--- a/year1/units/unit8/csStandards.md
+++ b/year1/units/unit8/csStandards.md
@@ -1,8 +1,8 @@
-#Unit 8: JavaScript Introduction
+# Unit 8: JavaScript Introduction
 
 ## Standards Alignment
 
-####Common Core
+#### Common Core
 **[CCSS.ELA-Literacy.W.9-10.6](http://www.corestandards.org/ELA-Literacy/W/9-10/2/)** Use technology, including the Internet, to produce, publish, and update individual or shared writing products, taking advantage of technology’s capacity to link to other information and to display information flexibly and dynamically.  
 
 **[CCSS.MATH.PRACTICE.MP3](http://www.corestandards.org/Math/Practice/#CCSS.Math.Practice.MP3)**: Construct viable arguments and critique the reasoning of others.
@@ -13,7 +13,7 @@
 **[CCSS.MATH.PRACTICE.MP8](http://www.corestandards.org/Math/Practice/#CCSS.Math.Practice.MP8)**: Look for and express regularity in repeated reasoning.
 
 
-####CSTA
+#### CSTA
 **CT.L2-03** Define an algorithm as a sequence of instructions that can be processed by a computer.
 
 **CT.L2-04** Evaluate ways that different algorithms may be used to solve the same problem.

--- a/year1/units/unit8/projects/project1/README.md
+++ b/year1/units/unit8/projects/project1/README.md
@@ -1,13 +1,13 @@
-#Unit 8: Project 1 || Tiny Turtle
+# Unit 8: Project 1 || Tiny Turtle
 
 
-##Scope
+## Scope
 This project has the students complete their Tiny Turtle project to create shapes from procedural commands made to the turtle in the form of functions.
 
-##Estimated Completion Time
+## Estimated Completion Time
 This project should take 45 minutes to complete. Project may take less or more time depending on students' needs.  
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * This project is being continued from Lesson 2 of this unit.
 * If a student was absent during lesson 2 they can begin with this [this starter code](https://github.com/ScriptEdcurriculum/tinyTurtleUnit8AlternateStarter)
 * The students are making function calls in Tiny Turtle they are not creating their own functions quite yet.
@@ -21,7 +21,7 @@ This project should take 45 minutes to complete. Project may take less or more t
 
 ##[Google Slides](https://docs.google.com/presentation/d/1DQLzZokIkRzK9LYB5Zp6VmVGDXdaCd6NUt4n7XMwZLQ/edit?usp=sharing)
 
-##Project Extensions
+## Project Extensions
 If students complete this project early, they should be encouraged to make a variety of shapes with Tiny Turtle. Start with a hexagon!
 
 

--- a/year1/units/unit8/topics/topic1/README.md
+++ b/year1/units/unit8/topics/topic1/README.md
@@ -1,4 +1,4 @@
-#Unit 8: Topic 1 || JavaScript Discovery
+# Unit 8: Topic 1 || JavaScript Discovery
  ![Imgur](http://i.imgur.com/4soy0jZm.png)
  
 <table>

--- a/year1/units/unit9/README.md
+++ b/year1/units/unit9/README.md
@@ -1,4 +1,4 @@
-#Unit 9: JavaScript: Value Types, Operators, Variables, and Conditionals
+# Unit 9: JavaScript: Value Types, Operators, Variables, and Conditionals
 
 In this unit students are introduced to **Value Types, Operators, Variables, & Conditional Statements** through the course of making two games that ask the user to guess a certain word or number.
 <table>
@@ -38,7 +38,7 @@ In this unit students are introduced to **Value Types, Operators, Variables, & C
 </table>
 
 
-##Extra Resources, Challenges and Projects
+## Extra Resources, Challenges and Projects
 
 
 [Common Core & Computer Science Standards Alignment](csStandards.md)
@@ -46,6 +46,6 @@ In this unit students are introduced to **Value Types, Operators, Variables, & C
 
 <a href="https://github.com/ScriptEdcurriculum/curriculum2016/wiki/foundationsCourse#unit-9-conditionals-variables--strings">ScriptEd Unit 9 Wiki</a> (check this out for additional resources and add your own!)
 
-##Submit Your Feedback
+## Submit Your Feedback
 <a href="https://docs.google.com/forms/d/e/1FAIpQLSfx0wkLyw_jSOhWR2yY8GTR8TV2NXYZc40us7aPHnl9bO6WAQ/viewform">Click here!</a>
 

--- a/year1/units/unit9/csStandards.md
+++ b/year1/units/unit9/csStandards.md
@@ -1,9 +1,9 @@
-#Unit 9: Conditionals, Variables, Strings
+# Unit 9: Conditionals, Variables, Strings
 
 
 ## Standards Alignment
 
-####Common Core
+#### Common Core
 **[CCSS.ELA-Literacy.W.9-10.6](http://www.corestandards.org/ELA-Literacy/W/9-10/2/)** Use technology, including the Internet, to produce, publish, and update individual or shared writing products, taking advantage of technology’s capacity to link to other information and to display information flexibly and dynamically.  
 
 **[CCSS.ELA-Literacy.RH.9-10.9](http://www.corestandards.org/ELA-Literacy/RH/9-10/9/)** Compare and contrast treatments of the same topic in several primary and secondary sources.
@@ -17,7 +17,7 @@
 **[CCSS.MATH.PRACTICE.MP8](http://www.corestandards.org/Math/Practice/#CCSS.Math.Practice.MP8)**: Look for and express regularity in repeated reasoning.
 
 
-####CSTA
+#### CSTA
 **CT.L2-03** Define an algorithm as a sequence of instructions that can be processed by a computer.
 
 **CT.L2-04** Evaluate ways that different algorithms may be used to solve the same problem.

--- a/year1/units/unit9/projects/project1/README.md
+++ b/year1/units/unit9/projects/project1/README.md
@@ -1,13 +1,13 @@
-#Unit 9: Project 1 || Password Guesser
+# Unit 9: Project 1 || Password Guesser
 
 
-##Scope
+## Scope
 This project has the students combine their knowledge of variables, strings and conditionals with previously learned skills to create a word guessing game.
 
-##Estimated Completion Time
+## Estimated Completion Time
 This project should take 135 minutes to complete. Project may take less or more time depending on students' needs.  
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * Encourage students to look into old Gists for similar code that can be helpful.
 * This project will likely be very challenging. It is possible at least one extra mini-lesson will have to be given to the class while building this project. 
 * Setting up the environment will take time. Practice makes perfect!
@@ -21,7 +21,7 @@ This project should take 135 minutes to complete. Project may take less or more 
 
 ##[Google Slides](https://docs.google.com/a/scripted.org/presentation/d/1CF_SONTyu3AnP98J7WcwHtU9_vUKRTYZlZ6yn8POZk4/edit?usp=sharing)
 
-##Project Extensions
+## Project Extensions
 If students complete this project early, they should be encouraged to add CSS. They may also add a feature that says "Nope, that is not the Secret Word... Try again" if the user is incorrect.
 
 

--- a/year1/units/unit9/projects/project2/README.md
+++ b/year1/units/unit9/projects/project2/README.md
@@ -1,13 +1,13 @@
-#Unit 9: Project 2 || HiLo
+# Unit 9: Project 2 || HiLo
 
 
-##Scope
+## Scope
 This project asks the students to create a game called HiLo. The premise is to guess a number predetermined by the program.
 
-##Estimated Completion Time
+## Estimated Completion Time
 This project should take 90 minutes to complete. Project may take less or more time depending on students' needs.  
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * Challenge the students to discover how to create If/Else if/Else statements on their own. Self discovery is a useful skill!
 * There are many way to extend this project for students who are moving quickly. Feel free to extend for whole class if you feel it is useful.
 
@@ -19,7 +19,7 @@ This project should take 90 minutes to complete. Project may take less or more t
 
 ##[Google Slides](https://docs.google.com/presentation/d/1yzZdux-cRBL9cwGS49WwOfbdivNPI0TOvf_6yx1FF9w/edit#slide=id.g11512f67a7_0_57)
 
-##Project Extensions
+## Project Extensions
 If students complete this project early, they should be encouraged to...
 
 * Add interesting CSS to this project

--- a/year1/units/unit9/topics/topic1/README.md
+++ b/year1/units/unit9/topics/topic1/README.md
@@ -1,4 +1,4 @@
-#Unit 9: Topic 1 || Value Types and Operators
+# Unit 9: Topic 1 || Value Types and Operators
  ![Imgur](https://media.tenor.co/images/c376682ee95c470af51edf47e1051541/raw)
  
 <table>

--- a/year1/units/unit9/topics/topic2/README.md
+++ b/year1/units/unit9/topics/topic2/README.md
@@ -1,4 +1,4 @@
-#Unit 9: Topic 2 || Variables and If Statements
+# Unit 9: Topic 2 || Variables and If Statements
  ![Imgur](http://i.imgur.com/6cwaNWa.jpg)
  
 <table>

--- a/year1/units/unit9/topics/topic3/README.md
+++ b/year1/units/unit9/topics/topic3/README.md
@@ -1,4 +1,4 @@
-#Unit 9: Topic 3 || If/Else
+# Unit 9: Topic 3 || If/Else
  ![Imgur](http://i.imgur.com/7sqWy7Am.png)
  
 <table>

--- a/year1/units/unitReview/README.md
+++ b/year1/units/unitReview/README.md
@@ -1,4 +1,4 @@
-#Review Unit
+# Review Unit
 
 In this unit the students are given a mid-year challenge in HackerRank. It will test all of the skills learned until this point. Teachers are then given the opportunity to have students create a project that requires the students to practice skills that require more attention before moving onto unit 8. Also included in this unit is a trivia lesson designed to review content before students take the mid-year challenge.
 
@@ -25,7 +25,7 @@ In this unit the students are given a mid-year challenge in HackerRank. It will 
 </table>
 
 
-##Extra Resources, Challenges and Projects
+## Extra Resources, Challenges and Projects
 [Common Core & Computer Science Standards Alignment](csStandards.md)
 
 

--- a/year1/units/unitReview/csStandards.md
+++ b/year1/units/unitReview/csStandards.md
@@ -1,9 +1,9 @@
-#Review Unit
+# Review Unit
 
 
 ## Standards Alignment
 
-####Common Core
+#### Common Core
 **[CCSS.ELA-Literacy.W.9-10.6](http://www.corestandards.org/ELA-Literacy/W/9-10/2/)** Use technology, including the Internet, to produce, publish, and update individual or shared writing products, taking advantage of technology’s capacity to link to other information and to display information flexibly and dynamically.  
 
 **[CCSS.ELA-Literacy.RST.9-10.3](http://www.corestandards.org/ELA-Literacy/RST/9-10/3/)** Follow precisely a complex multistep procedure when carrying out experiments, taking measurements, or performing technical tasks, attending to special cases or exceptions defined in the text.
@@ -17,7 +17,7 @@
 **[CCSS.MATH.PRACTICE.MP8](http://www.corestandards.org/Math/Practice/#CCSS.Math.Practice.MP8)**: Look for and express regularity in repeated reasoning.
 
 
-####CSTA
+#### CSTA
 **CT.L2-03** Define an algorithm as a sequence of instructions that can be processed by a computer.
 
 **CT.L2-04** Evaluate ways that different algorithms may be used to solve the same problem.

--- a/year1/units/unitReview/topics/topic1/README.md
+++ b/year1/units/unitReview/topics/topic1/README.md
@@ -1,4 +1,4 @@
-#Review Unit: Topic 1 || Mid-term Trivia
+# Review Unit: Topic 1 || Mid-term Trivia
  ![Imgur](https://upload.wikimedia.org/wikipedia/en/2/27/Trivia.png)
   
 <table>

--- a/year1/units/unitReview/topics/topic2/README.md
+++ b/year1/units/unitReview/topics/topic2/README.md
@@ -1,4 +1,4 @@
-#Review Unit: Mid-Year Challenge
+# Review Unit: Mid-Year Challenge
  ![Imgur](http://i.imgur.com/uRbrxKHm.jpg)
   
 <table>

--- a/year1/units/unitReview/topics/topic3/README.md
+++ b/year1/units/unitReview/topics/topic3/README.md
@@ -1,4 +1,4 @@
-#Review Unit: Topic 3 || School Site Rebuild
+# Review Unit: Topic 3 || School Site Rebuild
  ![Imgur](http://i.imgur.com/TdNB0yfm.png)
   
 <table>

--- a/year2/README.md
+++ b/year2/README.md
@@ -19,7 +19,7 @@ Advanced Course
 | 1 session| [Technical Interviewing](units/8-techInterviewing) | Professional Skills| What to expect in a technical interview and Staying involved in the Tech community. |
 | 8-10 sessions | [Entreprenuership Project](units/9-entrepreneur) | Project Management| Students will be creating their own product in small teams. |
 
-####Misc Lessons, Games and Projects
+#### Misc Lessons, Games and Projects
 
 | Lesson | Description |
 |-------|:-------:|

--- a/year2/units/0-intro/README.md
+++ b/year2/units/0-intro/README.md
@@ -1,4 +1,4 @@
-#Advanced Class Launch Event 
+# Advanced Class Launch Event 
 
 All advanced students will meet at a central location. At this event, students will learn about the expectations for the course, meet the larger Advanced Program student community, and be notified of their company placement.
 

--- a/year2/units/1-review/README.md
+++ b/year2/units/1-review/README.md
@@ -1,7 +1,7 @@
-#Unit: Foundations Course Review 
+# Unit: Foundations Course Review 
 
 
-##Scope
+## Scope
 This unit will begin with introductions and icebreakers, a review of expectations, and a company orientation. Students will then compete in an activity that will test their knowledge of concepts taught in the first year of ScriptEd. After which, teachers will spend some time covering some foundational skills. The teachers may choose which skills need to be revisited. 
 
 <br>
@@ -11,7 +11,7 @@ This unit will begin with introductions and icebreakers, a review of expectation
 |[Scavenger Hunt](project1) | The beginning of first session should be allotted for icebreakers, expectations, and a company orientation. Students will then pair up to complete a [series of challenges](project1/clues.md) that will test their skills on topics covered in ScriptEd year 1. | 
 |[Review](project2)| In this session volunteers may choose to revisit certain skills from the first year curriculum if they feel the class needs the refresher. Volunteers may choose which units (if any) need revisiting. **This project may be skipped if the volunteer team feels a refresher is not necessary for the class as a whole.**|
 
-##Extra Resources, Challenges and Projects
+## Extra Resources, Challenges and Projects
 [Computer Science Standards Alignment](csStandards.md)
 
 

--- a/year2/units/1-review/csStandards.md
+++ b/year2/units/1-review/csStandards.md
@@ -1,8 +1,8 @@
-##Year 2  unit:review
+## Year 2  unit:review
 
 ## Standards Alignment
 
-####Common Core
+#### Common Core
 **[CCSS.ELA-Literacy.W.9-10.6](http://www.corestandards.org/ELA-Literacy/W/9-10/2/)** Use technology, including the Internet, to produce, publish, and update individual or shared writing products, taking advantage of technology’s capacity to link to other information and to display information flexibly and dynamically.  
 
 **[CCSS.ELA-Literacy.RH.9-10.9](http://www.corestandards.org/ELA-Literacy/RH/9-10/9/)** Compare and contrast treatments of the same topic in several primary and secondary sources.
@@ -17,7 +17,7 @@
 **[CCSS.MATH.PRACTICE.MP8](http://www.corestandards.org/Math/Practice/#CCSS.Math.Practice.MP8)**: Look for and express regularity in repeated reasoning.
 
 
-####CSTA
+#### CSTA
 **CT.L2-03** Define an algorithm as a sequence of instructions that can be processed by a computer.
 
 **CT.L2-04** Evaluate ways that different algorithms may be used to solve the same problem.

--- a/year2/units/1-review/project1/README.md
+++ b/year2/units/1-review/project1/README.md
@@ -1,14 +1,14 @@
-#Unit Review: Project 1 || Scavenger Hunt
+# Unit Review: Project 1 || Scavenger Hunt
 
 
-##Scope
+## Scope
 The beginning of first session should be allotted for icebreakers, expectations, and a company orientation. Students will then pair up to complete a [series of challenges](clues.md) that will test their skills on topics covered in ScriptEd year 1. 
 
 
-##Estimated Completion Time
+## Estimated Completion Time
 After icebreakers, expectation setting, and a company orientation, the goal should be for students to **begin** the Scavenger Hunt in session 1.  They come back together in their pairs to complete the actvity during session 2.  No more than 120 minutes should be allocated to the Scavenger Hunt. 
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 *For the Scavenger Hunt,*
 * Print copies of the [clues worksheet](clues.md) before class.
 * Require students to pair up with someone who is not in their school. Create a community within the class!
@@ -22,7 +22,7 @@ After icebreakers, expectation setting, and a company orientation, the goal shou
 
 ##[Google Slides](https://docs.google.com/presentation/d/1IBuckUNnsTBvcRPv8AjgffajG1YFVkSW4-Ik8xYn-ik/edit#slide=id.g135945ce02_0_222)
 
-##Project Extensions
+## Project Extensions
 There are plenty of challenges for this project, so students finishing early should not be an issue. It is likely no group will complete all the tasks.
 
 

--- a/year2/units/1-review/project1/clues.md
+++ b/year2/units/1-review/project1/clues.md
@@ -1,9 +1,9 @@
-#Scavenger Hunt Clues
+# Scavenger Hunt Clues
 ![Image](http://i.imgur.com/7PecKI9.png)
 
 
 ===================
-####HTML/CSS
+#### HTML/CSS
 These programs must be completed in either jsBin or cloud9.
 
 | Clue  | Name | Create a webpage/website that... | Points | 
@@ -18,7 +18,7 @@ These programs must be completed in either jsBin or cloud9.
 
   
   
-####JavaScript: Variables & Strings
+#### JavaScript: Variables & Strings
 
 | Clue  | Name | Create a program that... | Points | 
 |-------|:-------:|------|--------------|
@@ -28,7 +28,7 @@ These programs must be completed in either jsBin or cloud9.
 | 10 | roman.js  | ...can convert any integer from 1-100 into a roman numeral.| 20 |  
 
 
-####JavaScript: Conditionals
+#### JavaScript: Conditionals
 
 | Clue  | Name | Create a program that... | Points | 
 |-------|:-------:|------|--------------|
@@ -36,7 +36,7 @@ These programs must be completed in either jsBin or cloud9.
 | 3 | class.js | ...asks a student what grade they are in and responds with "You are a Freshman", "Sophomore", "Junior" or "Senior". | 5 |
 | 4 | grade.js | ...can convert a test grade (1-100) to a letter grade (A-F). | 10|
 
-####JavaScript: Functions
+#### JavaScript: Functions
 
 | Clue  | Name | Create a program that... | Points | 
 |-------|:-------:|------|--------------|
@@ -44,7 +44,7 @@ These programs must be completed in either jsBin or cloud9.
 | 2 | timesTwo | ...has a parameter of x and returns the value of 2x  | 4 | 
 
 
-####JavaScript: Loops
+#### JavaScript: Loops
 
 | Clue  | Name | Create a program that... | Points | 
 |-------|:-------:|------|--------------|
@@ -52,7 +52,7 @@ These programs must be completed in either jsBin or cloud9.
 | 2 | sum55.js | ...prints the sum of the numbers 1 through 55. (final value is 1540) | 4 | 
 | 3 | prod15.js | ...prints the product of the numbers 1 through 15. (final value is 1307674368000)  | 4 |
 
-####JavaScript: Loops/Arrays
+#### JavaScript: Loops/Arrays
 
 | Clue  | Name | Create a program that... | Points | 
 |-------|:-------:|------|--------------|
@@ -62,7 +62,7 @@ These programs must be completed in either jsBin or cloud9.
 | 4 | 99bottles.js | ...counts down from 99 to 1 repeating the string "# bottles of milk on the wall, # bottles of milk". | 5 | 
 
 
-####jQuery
+#### jQuery
 
 | Clue  | Name | Create a program that... | Points | 
 |-------|:-------:|------|--------------|
@@ -71,7 +71,7 @@ These programs must be completed in either jsBin or cloud9.
 | 3 |  Clicking | ...create a page that when a user clicks on a div tag it will hide from site.  | 4 | 
 | 4 | Hello Name Input | ...asks the user for their name in an input field then prints a greeting to you in a p tag on the page after they click a button  | 10 | 
 
-####GitHub
+#### GitHub
 
 | Clue  | Name | Create a program that... | Points | 
 |-------|:-------:|------|--------------|

--- a/year2/units/1-review/project2/README.md
+++ b/year2/units/1-review/project2/README.md
@@ -1,19 +1,19 @@
-#Unit Review: Project 2 || Foundations Review
+# Unit Review: Project 2 || Foundations Review
 
 
-##Scope
+## Scope
 In this session volunteers may choose to revisit certain skills from the first year curriculum if they feel the class needs the refresher. Volunteers may choose which units (if any) need revisiting. **This project may be skipped if the volunteer team feels a refresher is not necessary for the class as a whole.**
 
 
-##Estimated Completion Time
+## Estimated Completion Time
 No more than two 120 minutes should be allocated to this project. 
 
-##Year 1 Curriculum
+## Year 1 Curriculum
 
 * The 2015 ScriptEd Year 1 Curriculum can be found [here](github.com/ScriptEdcurriculum/curriculum2015)   
 * The 2016 ScriptEd Year 1 Curriculum can be found [here](github.com/ScriptEdcurriculum/curriculum2016) 
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * Students have already seen the lessons in the 2015 curriculum. Teachers may use their discretion to give the same lesson they have seen last year or to approach a skill from a new lesson.
 * Be very clear with the students in saying that in this advanced course we will move onto some awesome new skills. But for now we will fortify the concepts learned in year 1.
 

--- a/year2/units/2-websiteRedesign/README.md
+++ b/year2/units/2-websiteRedesign/README.md
@@ -1,13 +1,13 @@
-#Unit: Website Redesign with Bootstrap
+# Unit: Website Redesign with Bootstrap
 
 
-##Scope
+## Scope
 This unit will ask the students to pair up and redesign the homepage for the company that this course is meeting in. Students will be asked to wireframe, paired program, implement Bootstrap CSS and push changes to GitHub pages. 
 
-##Estimated Completion Time
+## Estimated Completion Time
 This unit should take 2 sessions to complete. Project may take less or more time depending on students' needs but should not exceed 3 sessions.  
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * The first portion of this project is a refresher on Bootstrap. Students are expected to understand it already but may require a longer lesson than what is already in the slides.
 * Presentations are key for building professional skills!
 
@@ -20,7 +20,7 @@ This unit should take 2 sessions to complete. Project may take less or more time
 
 ##[Google Slides](https://docs.google.com/presentation/d/1WJ4IBXeqAGkI6mhQIs6oWmMDOUtYgcb5h7j9zSy7qh4/edit?usp=sharing)
 
-##Project Extensions
+## Project Extensions
 Students who complete this task early are encouraged to:
 
 * Design can always be improved!! Teams can continue to hack away on their sites.

--- a/year2/units/3-portfolio/README.md
+++ b/year2/units/3-portfolio/README.md
@@ -1,13 +1,13 @@
-#Unit: Portfolio
+# Unit: Portfolio
 
 
-##Scope
+## Scope
 In this session students will create a professional portfoilio in which they can upload all their projects to.
 
-##Estimated Completion Time
+## Estimated Completion Time
 This unit should take 1 sessions to complete. 
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * There is ALOT of starter code in this project. Students should simply be plugging in links to their projects.
 * Site preview links can be created using either rawgit or GitHub pages
 
@@ -20,7 +20,7 @@ This unit should take 1 sessions to complete.
 
 ##[Google Slides](https://docs.google.com/presentation/d/1n5jYLGwAqVsr5XrGREWyTVKOeUPRQvlPCE-WyIV-4hI/edit?usp=sharing)
 
-##Project Extensions
+## Project Extensions
 Students who complete this task early are encouraged to:
 
 * Ensure their old projects run properly.

--- a/year2/units/4-RPS/README.md
+++ b/year2/units/4-RPS/README.md
@@ -1,13 +1,13 @@
-#Unit: Rock Paper Scissors
+# Unit: Rock Paper Scissors
 
 
-##Scope
+## Scope
 This unit will ask the students to create a Rock, Paper, Scissors game. This particular project is completed in two stages. Students will first create a functioning game that operates in the console. Then they will create a fully functioning game that operates with clicking events. 
 
-##Estimated Completion Time
+## Estimated Completion Time
 This unit should take 2 sessions to complete. Project may take less or more time depending on students' needs but should not exceed 3 sessions.  
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 
 * Follow the steps set out in the comments of the script.js files
 * Print copies of the Do Now before class. 
@@ -24,7 +24,7 @@ This unit should take 2 sessions to complete. Project may take less or more time
 
 ##[Google Slides](https://docs.google.com/presentation/d/1Srin1A05uT-jCEj8PhyhRqlKlavs8klrwd07ojnsNQk/edit#slide=id.g135945ce02_0_222)
 
-##Project Extensions
+## Project Extensions
 Students who complete this task early are encouraged to:
 
 * Add CSS to this project

--- a/year2/units/5-JSobjects/README.md
+++ b/year2/units/5-JSobjects/README.md
@@ -1,13 +1,13 @@
-#Unit: JavaScript Objects
+# Unit: JavaScript Objects
 
 
-##Scope
+## Scope
 This unit will cover the basics of JavaScript objects. It will begin with a 45 minute lesson on objects and will then ask the students to create a project that incorporates what they have learned. The goal of this unit is to have the students become comfortable working with objects so that they can then work with API requests.
 
-##Estimated Completion Time
+## Estimated Completion Time
 This unit should take 120 minutes to complete. The project may take less or more time depending on students' needs.  
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * It is encouraged that the teachers in the class complete this project beforehand to understand what issues the students might encounter.
 * Students may or may not have an understanding of objects already. Practice makes perfect! 
 * Task 4 can be extremely challenging! It is recommended to not spend more than one class on this project. Do not spend a lot of time ensuring all students complete task 4. A better use of the class's time would be to move onto the next project after all students have completed task 3.
@@ -21,7 +21,7 @@ This unit should take 120 minutes to complete. The project may take less or more
 
 ##[Google Slides](https://docs.google.com/presentation/d/1esamRfyAFhl2quGDxt3-NRvHLHwhFad9g-sYucYJlFg/edit?usp=sharing)
 
-##Project Extensions
+## Project Extensions
 Students who complete this task early are encouraged to:
 
 * add more values to elements (youtube URLs, images, etc.).

--- a/year2/units/6-giphyAPI/README.md
+++ b/year2/units/6-giphyAPI/README.md
@@ -1,13 +1,13 @@
-#Unit: Giphy API
+# Unit: Giphy API
 
 
-##Scope
+## Scope
 In this session, students will create a webapp using the Giphy API. The webapp will consist of an input field and button that will be used to display gifs based on user input.
 
-##Estimated Completion Time
+## Estimated Completion Time
 This unit should take 2 sessions to complete. Project may take less or more time depending on students' needs but should not exceed 3 sessions.  
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * Students will be introduced to JSON in this project. For now, it is best to compare an API call to just being a large object.
 
 <br>
@@ -19,7 +19,7 @@ This unit should take 2 sessions to complete. Project may take less or more time
 
 ##[Google Slides](https://docs.google.com/presentation/d/1ialkqyBF_Ft_CvAi4rBjIsFvUvu8x4mRpuYDZs0nLA0/edit?usp=sharing)
 
-##Project Extensions
+## Project Extensions
 Students who complete this task early are encouraged to:
 
 * Create a loop that displays the images on the page

--- a/year2/units/7-openWeatherAPI/README.md
+++ b/year2/units/7-openWeatherAPI/README.md
@@ -1,13 +1,13 @@
-#Unit: Open Weather API
+# Unit: Open Weather API
 
 
-##Scope
+## Scope
 In this session, students will create a webapp using the Open Weather API. The webapp will consist of an input field and a button that will be used to display weather dependant on the area the user queries. 
 
-##Estimated Completion Time
+## Estimated Completion Time
 This unit should take 2 sessions to complete. Project may take less or more time depending on students' needs but should not exceed 3 sessions.  
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * The protocol might need to change on the API endpoint depending on the network you are on. HTTPS seems to be buggy with Open Weather.  
 <br>
 
@@ -18,7 +18,7 @@ This unit should take 2 sessions to complete. Project may take less or more time
 
 ##[Google Slides](https://docs.google.com/presentation/d/1lQ2SeIdKKtR7wGXC1O1yp8Nq1cga2drVU8gTDPMbtnI/edit?usp=sharing)
 
-##Project Extensions
+## Project Extensions
 Students who complete this task early are encouraged to:
 
 * Add CSS

--- a/year2/units/8-techInterviewing/README.md
+++ b/year2/units/8-techInterviewing/README.md
@@ -1,13 +1,13 @@
-#Unit: Technical Interviewing
+# Unit: Technical Interviewing
 
 
-##Scope
+## Scope
 In this session, students will be introduced to what they can expect from a technical interview. It also asks them to make first steps into becoming a member of the greater tech community outside of ScriptEd.
 
-##Estimated Completion Time
+## Estimated Completion Time
 This activity will take one ScriptEd session  
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * Use personal stories of interviews you have been through.
 * Students will be asked to look for Hackathons they might want to participate in. If you have interest and capacity. you can create a team with teachers and students for an upcoming hackathon in NYC.
 

--- a/year2/units/9-entrepreneur/README.md
+++ b/year2/units/9-entrepreneur/README.md
@@ -1,6 +1,6 @@
-#Unit: Entrepreneurship Project
+# Unit: Entrepreneurship Project
 
-##Scope
+## Scope
 In this session, students will work in pairs to create a project from scratch. This project is intended to highlight some very important aspects of being a quality engineer that include:
 
 * Being a self-starter
@@ -8,10 +8,10 @@ In this session, students will work in pairs to create a project from scratch. T
 * Learning while creating
 * Time management
 
-##Estimated Completion Time
+## Estimated Completion Time
 This project is designed to take between 8 and 10 sessions.
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * Start small! Simple projects can become more detailed. Large projects often go unfinished.
 * Structure each session with a do now, time to build and scrum.
 * Require daily goals

--- a/year2/units/midYearChallenge/README.md
+++ b/year2/units/midYearChallenge/README.md
@@ -1,4 +1,4 @@
-#Mid-Year Coding Challenge
+# Mid-Year Coding Challenge
  ![Imgur](http://i.imgur.com/uRbrxKHm.jpg)
  
 In this unit the students are given a mid-year challenge in HackerRank. Students must take this seriously as internship placements will be affected by the results of this challenge. The average student should take 30 minutes to complete this challenge. However, please allot 45 minutes to complete it.
@@ -12,7 +12,7 @@ In this unit the students are given a mid-year challenge in HackerRank. Students
 </table>
 
 
-##Extra Resources, Challenges and Projects
+## Extra Resources, Challenges and Projects
 [Common Core & Computer Science Standards Alignment](csStandards.md)
 
 

--- a/year2/units/midYearChallenge/csStandards.md
+++ b/year2/units/midYearChallenge/csStandards.md
@@ -1,9 +1,9 @@
-#Review Unit
+# Review Unit
 
 
 ## Standards Alignment
 
-####Common Core
+#### Common Core
 **[CCSS.ELA-Literacy.W.9-10.6](http://www.corestandards.org/ELA-Literacy/W/9-10/2/)** Use technology, including the Internet, to produce, publish, and update individual or shared writing products, taking advantage of technology’s capacity to link to other information and to display information flexibly and dynamically.  
 
 **[CCSS.ELA-Literacy.RST.9-10.3](http://www.corestandards.org/ELA-Literacy/RST/9-10/3/)** Follow precisely a complex multistep procedure when carrying out experiments, taking measurements, or performing technical tasks, attending to special cases or exceptions defined in the text.
@@ -17,7 +17,7 @@
 **[CCSS.MATH.PRACTICE.MP8](http://www.corestandards.org/Math/Practice/#CCSS.Math.Practice.MP8)**: Look for and express regularity in repeated reasoning.
 
 
-####CSTA
+#### CSTA
 **CT.L2-03** Define an algorithm as a sequence of instructions that can be processed by a computer.
 
 **CT.L2-04** Evaluate ways that different algorithms may be used to solve the same problem.

--- a/year2/units/midYearChallenge/topics/topic1/README.md
+++ b/year2/units/midYearChallenge/topics/topic1/README.md
@@ -1,4 +1,4 @@
-#Review Unit: Topic 1 || Mid-term Trivia
+# Review Unit: Topic 1 || Mid-term Trivia
  ![Imgur](https://upload.wikimedia.org/wikipedia/en/2/27/Trivia.png)
   
 <table>

--- a/year2/units/midYearChallenge/topics/topic2/README.md
+++ b/year2/units/midYearChallenge/topics/topic2/README.md
@@ -1,4 +1,4 @@
-#Review Unit: Mid-Year Challenge
+# Review Unit: Mid-Year Challenge
  ![Imgur](http://i.imgur.com/uRbrxKHm.jpg)
   
 <table>

--- a/year2/units/midYearChallenge/topics/topic3/README.md
+++ b/year2/units/midYearChallenge/topics/topic3/README.md
@@ -1,4 +1,4 @@
-#Review Unit: Topic 3 || School Site Rebuild
+# Review Unit: Topic 3 || School Site Rebuild
  ![Imgur](http://i.imgur.com/TdNB0yfm.png)
   
 <table>

--- a/year2/units/opt-FoursquareAPI/README.md
+++ b/year2/units/opt-FoursquareAPI/README.md
@@ -1,13 +1,13 @@
-#Unit: Foursquare API
+# Unit: Foursquare API
 
 
-##Scope
+## Scope
 In this session, students will create a webapp using the Foursquare API. The webapp will consist of an input field and button that will be used to display relevant restaurants nearby of a specified food category. 
 
-##Estimated Completion Time
+## Estimated Completion Time
 This unit should take 2 sessions to complete. Project may take less or more time depending on students' needs but should not exceed 3 sessions.  
 
-##Teacher Notes & Pro Tips
+## Teacher Notes & Pro Tips
 * The HTTP request found [here](https://developer.foursquare.com/start/search) has spaces in it. Students often get tripped up by this.
 
 <br>
@@ -19,7 +19,7 @@ This unit should take 2 sessions to complete. Project may take less or more time
 
 ##[Google Slides](https://docs.google.com/presentation/d/1z2iGx3tTcufLSjG1u1tOHCmh297R9loi6A1Rfq9rlKU/edit#slide=id.g135945ce02_0_222)
 
-##Project Extensions
+## Project Extensions
 Students who complete this task early are encouraged to:
 
 * Create a loop that displays the images on the page


### PR DESCRIPTION
When GitHub renders Markdown files, it requires a space after the hash marks to parse it as a header. This adds a space for all Markdown files where a hash mark didn't exist before.